### PR TITLE
Change node key type to BLS

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -1,0 +1,108 @@
+package bls
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/tendermint/tendermint/crypto"
+	herumi "github.com/tendermint/tendermint/crypto/bls/bls"
+	"github.com/tendermint/tendermint/crypto/tmhash"
+)
+
+// PrivKeyBls Wrap to herumi bls for tendermint crypto.PrivKey
+type PrivKeyBls struct {
+	SerializedPrivKey []byte            `json:"raw_priv_key"`
+	herumiPriv        *herumi.SecretKey //cache
+}
+
+// PubKeyBls Wrap to herumi bls for tendermint crypto.PubKey
+type PubKeyBls struct {
+	SerializedPubKey []byte            `json:"raw_pub_key"`
+	herumiPub        *herumi.PublicKey //cache
+}
+
+func init() {
+	herumi.Init(herumi.BLS12_381)
+}
+
+func GenerateKey() (PrivKeyBls, PubKeyBls) {
+	var rawPriv herumi.SecretKey
+	rawPriv.SetByCSPRNG()
+	rawPub := rawPriv.GetPublicKey()
+
+	serializedPriv := rawPriv.Serialize()
+	serializedPub := rawPub.Serialize()
+
+	return PrivKeyBls{SerializedPrivKey: serializedPriv}, PubKeyBls{SerializedPubKey: serializedPub}
+}
+
+func (privKey *PrivKeyBls) loadCache() error {
+	if len(privKey.SerializedPrivKey) == 0 {
+		return errors.New("serialized length is zero")
+	}
+
+	if privKey.herumiPriv == nil {
+		var herumiPriv herumi.SecretKey
+		if err := herumiPriv.Deserialize(privKey.SerializedPrivKey); err != nil {
+			return err
+		}
+		privKey.herumiPriv = &herumiPriv
+	}
+
+	return nil
+}
+
+func (privKey PrivKeyBls) Bytes() []byte {
+	data, _ := cdc.MarshalBinaryBare(privKey)
+	return data
+}
+
+func (privKey PrivKeyBls) Sign(msg []byte) ([]byte, error) {
+	if loadErr := privKey.loadCache(); loadErr != nil {
+		return nil, loadErr
+	}
+
+	herumiSign := privKey.herumiPriv.SignHash(msg)
+	return herumiSign.Serialize(), nil
+}
+
+func (privKey PrivKeyBls) PubKey() crypto.PubKey {
+	if loadErr := privKey.loadCache(); loadErr != nil {
+		panic("Cannot loaded herumi pubkey instance")
+	}
+	rawPub := privKey.herumiPriv.GetPublicKey()
+
+	return PubKeyBls{SerializedPubKey: rawPub.Serialize()}
+}
+
+func (privKey PrivKeyBls) Equals(rhs crypto.PrivKey) bool {
+	return bytes.Equal(privKey.SerializedPrivKey, rhs.(*PrivKeyBls).SerializedPrivKey)
+}
+
+func (pubKey PubKeyBls) Address() crypto.Address {
+	return crypto.Address(tmhash.SumTruncated(pubKey.SerializedPubKey))
+}
+func (pubKey PubKeyBls) Bytes() []byte {
+	data, _ := cdc.MarshalBinaryBare(pubKey)
+	return data
+}
+func (pubKey PubKeyBls) VerifyBytes(msg []byte, sig []byte) bool {
+	if pubKey.herumiPub == nil {
+		var rawPub herumi.PublicKey
+		if err := rawPub.Deserialize(pubKey.SerializedPubKey); err != nil {
+			return false
+		}
+
+		pubKey.herumiPub = &rawPub
+	}
+
+	var herumiSign herumi.Sign
+	if err := herumiSign.Deserialize(sig); err != nil {
+		return false
+	}
+	return herumiSign.VerifyHash(pubKey.herumiPub, msg)
+}
+
+func (pubKey PubKeyBls) Equals(rhs crypto.PubKey) bool {
+	return bytes.Equal(pubKey.SerializedPubKey, rhs.(*PubKeyBls).SerializedPubKey)
+}

--- a/crypto/bls/bls/bls.go
+++ b/crypto/bls/bls/bls.go
@@ -1,0 +1,638 @@
+package bls
+
+/*
+#cgo CFLAGS:-DMCLBN_FP_UNIT_SIZE=6 -DMCLBN_FR_UNIT_SIZE=4
+#cgo LDFLAGS:-lbls384_256 -lcrypto -lgmp -lgmpxx -lstdc++
+typedef unsigned int (*ReadRandFunc)(void *, void *, unsigned int);
+int wrapReadRandCgo(void *self, void *buf, unsigned int n);
+#include <bls/bls.h>
+*/
+import "C"
+import "fmt"
+import "unsafe"
+import "io"
+import "encoding/hex"
+
+func hex2byte(s string) ([]byte, error) {
+	if (len(s) & 1) == 1 {
+		return nil, fmt.Errorf("odd length")
+	}
+	return hex.DecodeString(s)
+}
+
+// Init --
+// call this function before calling all the other operations
+// this function is not thread safe
+func Init(curve int) error {
+	err := C.blsInit(C.int(curve), C.MCLBN_COMPILED_TIME_VAR)
+	if err != 0 {
+		return fmt.Errorf("ERR Init curve=%d", curve)
+	}
+	return nil
+}
+
+// ID --
+type ID struct {
+	v C.blsId
+}
+
+// Serialize --
+func (id *ID) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsIdSerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &id.v)
+	if n == 0 {
+		panic("err blsIdSerialize")
+	}
+	return buf[:n]
+}
+
+// Deserialize --
+func (id *ID) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.blsIdDeserialize(&id.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err blsIdDeserialize %x", buf)
+	}
+	return nil
+}
+
+// GetLittleEndian -- alias of Serialize
+func (id *ID) GetLittleEndian() []byte {
+	return id.Serialize()
+}
+
+// SetLittleEndian --
+func (id *ID) SetLittleEndian(buf []byte) error {
+	// #nosec
+	err := C.blsIdSetLittleEndian(&id.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsIdSetLittleEndian %x", err)
+	}
+	return nil
+}
+
+// SerializeToHexStr --
+func (id *ID) SerializeToHexStr() string {
+	return hex.EncodeToString(id.Serialize())
+}
+
+// DeserializeHexStr --
+func (id *ID) DeserializeHexStr(s string) error {
+	a, err := hex2byte(s)
+	if err != nil {
+		return err
+	}
+	return id.Deserialize(a)
+}
+
+// GetHexString --
+func (id *ID) GetHexString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsIdGetHexStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &id.v)
+	if n == 0 {
+		panic("err blsIdGetHexStr")
+	}
+	return string(buf[:n])
+}
+
+// GetDecString --
+func (id *ID) GetDecString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsIdGetDecStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &id.v)
+	if n == 0 {
+		panic("err blsIdGetDecStr")
+	}
+	return string(buf[:n])
+}
+
+// SetHexString --
+func (id *ID) SetHexString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsIdSetHexStr(&id.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsIdSetHexStr %s", s)
+	}
+	return nil
+}
+
+// SetDecString --
+func (id *ID) SetDecString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsIdSetDecStr(&id.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsIdSetDecStr %s", s)
+	}
+	return nil
+}
+
+// IsEqual --
+func (id *ID) IsEqual(rhs *ID) bool {
+	if id == nil || rhs == nil {
+		return false
+	}
+	return C.blsIdIsEqual(&id.v, &rhs.v) == 1
+}
+
+// SecretKey --
+type SecretKey struct {
+	v C.blsSecretKey
+}
+
+// Serialize --
+func (sec *SecretKey) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsSecretKeySerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &sec.v)
+	if n == 0 {
+		panic("err blsSecretKeySerialize")
+	}
+	return buf[:n]
+}
+
+// Deserialize --
+func (sec *SecretKey) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.blsSecretKeyDeserialize(&sec.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err blsSecretKeyDeserialize %x", buf)
+	}
+	return nil
+}
+
+// GetLittleEndian -- alias of Serialize
+func (sec *SecretKey) GetLittleEndian() []byte {
+	return sec.Serialize()
+}
+
+// SetLittleEndian --
+func (sec *SecretKey) SetLittleEndian(buf []byte) error {
+	// #nosec
+	err := C.blsSecretKeySetLittleEndian(&sec.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsSecretKeySetLittleEndian %x", err)
+	}
+	return nil
+}
+
+// SerializeToHexStr --
+func (sec *SecretKey) SerializeToHexStr() string {
+	return hex.EncodeToString(sec.Serialize())
+}
+
+// DeserializeHexStr --
+func (sec *SecretKey) DeserializeHexStr(s string) error {
+	a, err := hex2byte(s)
+	if err != nil {
+		return err
+	}
+	return sec.Deserialize(a)
+}
+
+// GetHexString --
+func (sec *SecretKey) GetHexString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsSecretKeyGetHexStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &sec.v)
+	if n == 0 {
+		panic("err blsSecretKeyGetHexStr")
+	}
+	return string(buf[:n])
+}
+
+// GetDecString --
+func (sec *SecretKey) GetDecString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsSecretKeyGetDecStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &sec.v)
+	if n == 0 {
+		panic("err blsSecretKeyGetDecStr")
+	}
+	return string(buf[:n])
+}
+
+// SetHexString --
+func (sec *SecretKey) SetHexString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsSecretKeySetHexStr(&sec.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsSecretKeySetHexStr %s", s)
+	}
+	return nil
+}
+
+// SetDecString --
+func (sec *SecretKey) SetDecString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsSecretKeySetDecStr(&sec.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsSecretKeySetDecStr %s", s)
+	}
+	return nil
+}
+
+// IsEqual --
+func (sec *SecretKey) IsEqual(rhs *SecretKey) bool {
+	if sec == nil || rhs == nil {
+		return false
+	}
+	return C.blsSecretKeyIsEqual(&sec.v, &rhs.v) == 1
+}
+
+// SetByCSPRNG --
+func (sec *SecretKey) SetByCSPRNG() {
+	err := C.blsSecretKeySetByCSPRNG(&sec.v)
+	if err != 0 {
+		panic("err blsSecretKeySetByCSPRNG")
+	}
+}
+
+// Add --
+func (sec *SecretKey) Add(rhs *SecretKey) {
+	C.blsSecretKeyAdd(&sec.v, &rhs.v)
+}
+
+// Sub --
+func (pub *PublicKey) Sub(rhs *PublicKey) {
+	if pub == nil || rhs == nil {
+		return
+	}
+	C.blsPublicKeySub(&pub.v, &rhs.v)
+}
+
+// GetMasterSecretKey --
+func (sec *SecretKey) GetMasterSecretKey(k int) (msk []SecretKey) {
+	msk = make([]SecretKey, k)
+	msk[0] = *sec
+	for i := 1; i < k; i++ {
+		msk[i].SetByCSPRNG()
+	}
+	return msk
+}
+
+// GetMasterPublicKey --
+func GetMasterPublicKey(msk []SecretKey) (mpk []PublicKey) {
+	n := len(msk)
+	mpk = make([]PublicKey, n)
+	for i := 0; i < n; i++ {
+		mpk[i] = *msk[i].GetPublicKey()
+	}
+	return mpk
+}
+
+// Set --
+func (sec *SecretKey) Set(msk []SecretKey, id *ID) error {
+	// #nosec
+	ret := C.blsSecretKeyShare(&sec.v, &msk[0].v, (C.mclSize)(len(msk)), &id.v)
+	if ret != 0 {
+		return fmt.Errorf("err blsSecretKeyShare")
+	}
+	return nil
+}
+
+// Recover --
+func (sec *SecretKey) Recover(secVec []SecretKey, idVec []ID) error {
+	if len(secVec) != len(idVec) {
+		return fmt.Errorf("err SecretKey.Recover bad size")
+	}
+	// #nosec
+	ret := C.blsSecretKeyRecover(&sec.v, &secVec[0].v, (*C.blsId)(&idVec[0].v), (C.mclSize)(len(idVec)))
+	if ret != 0 {
+		return fmt.Errorf("err blsSecretKeyRecover")
+	}
+	return nil
+}
+
+// GetPop --
+func (sec *SecretKey) GetPop() (sig *Sign) {
+	sig = new(Sign)
+	C.blsGetPop(&sig.v, &sec.v)
+	return sig
+}
+
+// PublicKey --
+type PublicKey struct {
+	v C.blsPublicKey
+}
+
+// Serialize --
+func (pub *PublicKey) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsPublicKeySerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &pub.v)
+	if n == 0 {
+		panic("err blsPublicKeySerialize")
+	}
+	return buf[:n]
+}
+
+// Deserialize --
+func (pub *PublicKey) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.blsPublicKeyDeserialize(&pub.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err blsPublicKeyDeserialize %x", buf)
+	}
+	return nil
+}
+
+// SerializeToHexStr --
+func (pub *PublicKey) SerializeToHexStr() string {
+	return hex.EncodeToString(pub.Serialize())
+}
+
+// DeserializeHexStr --
+func (pub *PublicKey) DeserializeHexStr(s string) error {
+	a, err := hex2byte(s)
+	if err != nil {
+		return err
+	}
+	return pub.Deserialize(a)
+}
+
+// GetHexString --
+func (pub *PublicKey) GetHexString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsPublicKeyGetHexStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &pub.v)
+	if n == 0 {
+		panic("err blsPublicKeyGetHexStr")
+	}
+	return string(buf[:n])
+}
+
+// SetHexString --
+func (pub *PublicKey) SetHexString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsPublicKeySetHexStr(&pub.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsPublicKeySetHexStr %s", s)
+	}
+	return nil
+}
+
+// IsEqual --
+func (pub *PublicKey) IsEqual(rhs *PublicKey) bool {
+	if pub == nil || rhs == nil {
+		return false
+	}
+	return C.blsPublicKeyIsEqual(&pub.v, &rhs.v) == 1
+}
+
+// Add --
+func (pub *PublicKey) Add(rhs *PublicKey) {
+	C.blsPublicKeyAdd(&pub.v, &rhs.v)
+}
+
+// Set --
+func (pub *PublicKey) Set(mpk []PublicKey, id *ID) error {
+	// #nosec
+	ret := C.blsPublicKeyShare(&pub.v, &mpk[0].v, (C.mclSize)(len(mpk)), &id.v)
+	if ret != 0 {
+		return fmt.Errorf("err blsPublicKeyShare")
+	}
+	return nil
+}
+
+// Recover --
+func (pub *PublicKey) Recover(pubVec []PublicKey, idVec []ID) error {
+	if len(pubVec) != len(idVec) {
+		return fmt.Errorf("err PublicKey.Recover bad size")
+	}
+	// #nosec
+	ret := C.blsPublicKeyRecover(&pub.v, &pubVec[0].v, (*C.blsId)(&idVec[0].v), (C.mclSize)(len(idVec)))
+	if ret != 0 {
+		return fmt.Errorf("err blsPublicKeyRecover")
+	}
+	return nil
+}
+
+// Sign  --
+type Sign struct {
+	v C.blsSignature
+}
+
+// Serialize --
+func (sig *Sign) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsSignatureSerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &sig.v)
+	if n == 0 {
+		panic("err blsSignatureSerialize")
+	}
+	return buf[:n]
+}
+
+// Deserialize --
+func (sig *Sign) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.blsSignatureDeserialize(&sig.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err blsSignatureDeserialize %x", buf)
+	}
+	return nil
+}
+
+// SerializeToHexStr --
+func (sig *Sign) SerializeToHexStr() string {
+	return hex.EncodeToString(sig.Serialize())
+}
+
+// DeserializeHexStr --
+func (sig *Sign) DeserializeHexStr(s string) error {
+	a, err := hex2byte(s)
+	if err != nil {
+		return err
+	}
+	return sig.Deserialize(a)
+}
+
+// GetHexString --
+func (sig *Sign) GetHexString() string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.blsSignatureGetHexStr((*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)), &sig.v)
+	if n == 0 {
+		panic("err blsSignatureGetHexStr")
+	}
+	return string(buf[:n])
+}
+
+// SetHexString --
+func (sig *Sign) SetHexString(s string) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.blsSignatureSetHexStr(&sig.v, (*C.char)(unsafe.Pointer(&buf[0])), C.mclSize(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err blsSignatureSetHexStr %s", s)
+	}
+	return nil
+}
+
+// IsEqual --
+func (sig *Sign) IsEqual(rhs *Sign) bool {
+	if sig == nil || rhs == nil {
+		return false
+	}
+	return C.blsSignatureIsEqual(&sig.v, &rhs.v) == 1
+}
+
+// GetPublicKey --
+func (sec *SecretKey) GetPublicKey() (pub *PublicKey) {
+	pub = new(PublicKey)
+	C.blsGetPublicKey(&pub.v, &sec.v)
+	return pub
+}
+
+// Sign -- Constant Time version
+func (sec *SecretKey) Sign(m string) (sig *Sign) {
+	sig = new(Sign)
+	buf := []byte(m)
+	// #nosec
+	C.blsSign(&sig.v, &sec.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	return sig
+}
+
+// Add --
+func (sig *Sign) Add(rhs *Sign) {
+	C.blsSignatureAdd(&sig.v, &rhs.v)
+}
+
+// Recover --
+func (sig *Sign) Recover(sigVec []Sign, idVec []ID) error {
+	if len(sigVec) != len(idVec) {
+		return fmt.Errorf("err Sign.Recover bad size")
+	}
+	// #nosec
+	ret := C.blsSignatureRecover(&sig.v, &sigVec[0].v, (*C.blsId)(&idVec[0].v), (C.mclSize)(len(idVec)))
+	if ret != 0 {
+		return fmt.Errorf("err blsSignatureRecover")
+	}
+	return nil
+}
+
+// Verify --
+func (sig *Sign) Verify(pub *PublicKey, m string) bool {
+	if sig == nil || pub == nil {
+		return false
+	}
+	buf := []byte(m)
+	// #nosec
+	return C.blsVerify(&sig.v, &pub.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf))) == 1
+}
+
+// VerifyPop --
+func (sig *Sign) VerifyPop(pub *PublicKey) bool {
+	if sig == nil || pub == nil {
+		return false
+	}
+	return C.blsVerifyPop(&sig.v, &pub.v) == 1
+}
+
+// DHKeyExchange --
+func DHKeyExchange(sec *SecretKey, pub *PublicKey) (out PublicKey) {
+	C.blsDHKeyExchange(&out.v, &sec.v, &pub.v)
+	return out
+}
+
+// HashAndMapToSignature --
+func HashAndMapToSignature(buf []byte) *Sign {
+	sig := new(Sign)
+	// #nosec
+	err := C.blsHashToSignature(&sig.v, unsafe.Pointer(&buf[0]), C.mclSize(len(buf)))
+	if err != 0 {
+		return nil
+	}
+	return sig
+}
+
+// VerifyPairing --
+func VerifyPairing(X *Sign, Y *Sign, pub *PublicKey) bool {
+	if X == nil || Y == nil || pub == nil {
+		return false
+	}
+	return C.blsVerifyPairing(&X.v, &Y.v, &pub.v) == 1
+}
+
+// SignHash --
+func (sec *SecretKey) SignHash(hash []byte) (sig *Sign) {
+	sig = new(Sign)
+	// #nosec
+	err := C.blsSignHash(&sig.v, &sec.v, unsafe.Pointer(&hash[0]), C.mclSize(len(hash)))
+	if err == 0 {
+		return sig
+	}
+	return nil
+}
+
+// VerifyHash --
+func (sig *Sign) VerifyHash(pub *PublicKey, hash []byte) bool {
+	if pub == nil {
+		return false
+	}
+	// #nosec
+	return C.blsVerifyHash(&sig.v, &pub.v, unsafe.Pointer(&hash[0]), C.mclSize(len(hash))) == 1
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+// VerifyAggregateHashes --
+func (sig *Sign) VerifyAggregateHashes(pubVec []PublicKey, hash [][]byte) bool {
+	if pubVec == nil {
+		return false
+	}
+	n := len(hash)
+	if n == 0 {
+		return false
+	}
+	hashByte := GetOpUnitSize() * 8
+	h := make([]byte, n*hashByte)
+	for i := 0; i < n; i++ {
+		hn := len(hash[i])
+		copy(h[i*hashByte:(i+1)*hashByte], hash[i][0:min(hn, hashByte)])
+	}
+	return C.blsVerifyAggregatedHashes(&sig.v, &pubVec[0].v, unsafe.Pointer(&h[0]), C.mclSize(hashByte), C.mclSize(n)) == 1
+}
+
+///
+
+var sRandReader io.Reader
+
+func createSlice(buf *C.char, n C.uint) []byte {
+	size := int(n)
+	return (*[1 << 30]byte)(unsafe.Pointer(buf))[:size:size]
+}
+
+// this function can't be put in callback.go
+//export wrapReadRandGo
+func wrapReadRandGo(buf *C.char, n C.uint) C.uint {
+	slice := createSlice(buf, n)
+	ret, err := sRandReader.Read(slice)
+	if ret == int(n) && err == nil {
+		return n
+	}
+	return 0
+}
+
+// SetRandFunc --
+func SetRandFunc(randReader io.Reader) {
+	sRandReader = randReader
+	if randReader != nil {
+		C.blsSetRandFunc(nil, C.ReadRandFunc(unsafe.Pointer(C.wrapReadRandCgo)))
+	} else {
+		// use default random generator
+		C.blsSetRandFunc(nil, C.ReadRandFunc(unsafe.Pointer(nil)))
+	}
+}

--- a/crypto/bls/bls/bls_test.go
+++ b/crypto/bls/bls/bls_test.go
@@ -1,0 +1,689 @@
+package bls
+
+import "testing"
+import "strconv"
+import "crypto/sha256"
+import "crypto/sha512"
+import "fmt"
+import "crypto/rand"
+
+var unitN = 0
+
+// Tests (for Benchmarks see below)
+
+func testPre(t *testing.T) {
+	t.Log("init")
+	{
+		var id ID
+		err := id.SetLittleEndian([]byte{6, 5, 4, 3, 2, 1})
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log("id :", id.GetHexString())
+		var id2 ID
+		err = id2.SetHexString(id.GetHexString())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !id.IsEqual(&id2) {
+			t.Errorf("not same id\n%s\n%s", id.GetHexString(), id2.GetHexString())
+		}
+		err = id2.SetDecString(id.GetDecString())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !id.IsEqual(&id2) {
+			t.Errorf("not same id\n%s\n%s", id.GetDecString(), id2.GetDecString())
+		}
+	}
+	{
+		var sec SecretKey
+		err := sec.SetLittleEndian([]byte{1, 2, 3, 4, 5, 6})
+		if err != nil {
+			t.Error(err)
+		}
+		t.Log("sec=", sec.GetHexString())
+	}
+
+	t.Log("create secret key")
+	m := "this is a bls sample for go"
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	t.Log("sec:", sec.GetHexString())
+	t.Log("create public key")
+	pub := sec.GetPublicKey()
+	t.Log("pub:", pub.GetHexString())
+	sign := sec.Sign(m)
+	t.Log("sign:", sign.GetHexString())
+	if !sign.Verify(pub, m) {
+		t.Error("Signature does not verify")
+	}
+
+	// How to make array of SecretKey
+	{
+		sec := make([]SecretKey, 3)
+		for i := 0; i < len(sec); i++ {
+			sec[i].SetByCSPRNG()
+			t.Log("sec=", sec[i].GetHexString())
+		}
+	}
+}
+
+func testStringConversion(t *testing.T) {
+	t.Log("testRecoverSecretKey")
+	var sec SecretKey
+	var s string
+	if unitN == 6 {
+		s = "16798108731015832284940804142231733909759579603404752749028378864165570215949"
+	} else {
+		s = "40804142231733909759579603404752749028378864165570215949"
+	}
+	err := sec.SetDecString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != sec.GetDecString() {
+		t.Error("not equal")
+	}
+	s = sec.GetHexString()
+	var sec2 SecretKey
+	err = sec2.SetHexString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sec.IsEqual(&sec2) {
+		t.Error("not equal")
+	}
+}
+
+func testRecoverSecretKey(t *testing.T) {
+	t.Log("testRecoverSecretKey")
+	k := 3000
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	t.Logf("sec=%s\n", sec.GetHexString())
+
+	// make master secret key
+	msk := sec.GetMasterSecretKey(k)
+
+	n := k
+	secVec := make([]SecretKey, n)
+	idVec := make([]ID, n)
+	for i := 0; i < n; i++ {
+		err := idVec[i].SetLittleEndian([]byte{byte(i & 255), byte(i >> 8), 2, 3, 4, 5})
+		if err != nil {
+			t.Error(err)
+		}
+		err = secVec[i].Set(msk, &idVec[i])
+		if err != nil {
+			t.Error(err)
+		}
+		//		t.Logf("idVec[%d]=%s\n", i, idVec[i].GetHexString())
+	}
+	// recover sec2 from secVec and idVec
+	var sec2 SecretKey
+	err := sec2.Recover(secVec, idVec)
+	if err != nil {
+		t.Error(err)
+	}
+	if !sec.IsEqual(&sec2) {
+		t.Errorf("Mismatch in recovered secret key:\n  %s\n  %s.", sec.GetHexString(), sec2.GetHexString())
+	}
+}
+
+func testEachSign(t *testing.T, m string, msk []SecretKey, mpk []PublicKey) ([]ID, []SecretKey, []PublicKey, []Sign) {
+	idTbl := []byte{3, 5, 193, 22, 15}
+	n := len(idTbl)
+
+	secVec := make([]SecretKey, n)
+	pubVec := make([]PublicKey, n)
+	signVec := make([]Sign, n)
+	idVec := make([]ID, n)
+
+	for i := 0; i < n; i++ {
+		err := idVec[i].SetLittleEndian([]byte{idTbl[i], 0, 0, 0, 0, 0})
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("idVec[%d]=%s\n", i, idVec[i].GetHexString())
+
+		err = secVec[i].Set(msk, &idVec[i])
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = pubVec[i].Set(mpk, &idVec[i])
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("pubVec[%d]=%s\n", i, pubVec[i].GetHexString())
+
+		if !pubVec[i].IsEqual(secVec[i].GetPublicKey()) {
+			t.Errorf("Pubkey derivation does not match\n%s\n%s", pubVec[i].GetHexString(), secVec[i].GetPublicKey().GetHexString())
+		}
+
+		signVec[i] = *secVec[i].Sign(m)
+		if !signVec[i].Verify(&pubVec[i], m) {
+			t.Error("Pubkey derivation does not match")
+		}
+	}
+	return idVec, secVec, pubVec, signVec
+}
+func testSign(t *testing.T) {
+	m := "testSign"
+	t.Log(m)
+
+	var sec0 SecretKey
+	sec0.SetByCSPRNG()
+	pub0 := sec0.GetPublicKey()
+	s0 := sec0.Sign(m)
+	if !s0.Verify(pub0, m) {
+		t.Error("Signature does not verify")
+	}
+
+	k := 3
+	msk := sec0.GetMasterSecretKey(k)
+	mpk := GetMasterPublicKey(msk)
+	idVec, secVec, pubVec, signVec := testEachSign(t, m, msk, mpk)
+
+	var sec1 SecretKey
+	err := sec1.Recover(secVec, idVec)
+	if err != nil {
+		t.Error(err)
+	}
+	if !sec0.IsEqual(&sec1) {
+		t.Error("Mismatch in recovered seckey.")
+	}
+	var pub1 PublicKey
+	err = pub1.Recover(pubVec, idVec)
+	if err != nil {
+		t.Error(err)
+	}
+	if !pub0.IsEqual(&pub1) {
+		t.Error("Mismatch in recovered pubkey.")
+	}
+	var s1 Sign
+	err = s1.Recover(signVec, idVec)
+	if err != nil {
+		t.Error(err)
+	}
+	if !s0.IsEqual(&s1) {
+		t.Error("Mismatch in recovered signature.")
+	}
+}
+
+func testAdd(t *testing.T) {
+	t.Log("testAdd")
+	var sec1 SecretKey
+	var sec2 SecretKey
+	sec1.SetByCSPRNG()
+	sec2.SetByCSPRNG()
+
+	pub1 := sec1.GetPublicKey()
+	pub2 := sec2.GetPublicKey()
+
+	m := "test test"
+	sign1 := sec1.Sign(m)
+	sign2 := sec2.Sign(m)
+
+	t.Log("sign1    :", sign1.GetHexString())
+	sign1.Add(sign2)
+	t.Log("sign1 add:", sign1.GetHexString())
+	pub1.Add(pub2)
+	if !sign1.Verify(pub1, m) {
+		t.Fail()
+	}
+}
+
+func testPop(t *testing.T) {
+	t.Log("testPop")
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	pop := sec.GetPop()
+	if !pop.VerifyPop(sec.GetPublicKey()) {
+		t.Errorf("Valid Pop does not verify")
+	}
+	sec.SetByCSPRNG()
+	if pop.VerifyPop(sec.GetPublicKey()) {
+		t.Errorf("Invalid Pop verifies")
+	}
+}
+
+func testData(t *testing.T) {
+	t.Log("testData")
+	var sec1, sec2 SecretKey
+	sec1.SetByCSPRNG()
+	b := sec1.GetLittleEndian()
+	err := sec2.SetLittleEndian(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sec1.IsEqual(&sec2) {
+		t.Error("SecretKey not same")
+	}
+	pub1 := sec1.GetPublicKey()
+	b = pub1.Serialize()
+	var pub2 PublicKey
+	err = pub2.Deserialize(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pub1.IsEqual(&pub2) {
+		t.Error("PublicKey not same")
+	}
+	m := "doremi"
+	sign1 := sec1.Sign(m)
+	b = sign1.Serialize()
+	var sign2 Sign
+	err = sign2.Deserialize(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sign1.IsEqual(&sign2) {
+		t.Error("Sign not same")
+	}
+}
+
+func testSerializeToHexStr(t *testing.T) {
+	t.Log("testSerializeToHexStr")
+	var sec1, sec2 SecretKey
+	sec1.SetByCSPRNG()
+	s := sec1.SerializeToHexStr()
+	err := sec2.DeserializeHexStr(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sec1.IsEqual(&sec2) {
+		t.Error("SecretKey not same")
+	}
+	pub1 := sec1.GetPublicKey()
+	s = pub1.SerializeToHexStr()
+	var pub2 PublicKey
+	err = pub2.DeserializeHexStr(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pub1.IsEqual(&pub2) {
+		t.Error("PublicKey not same")
+	}
+	m := "doremi"
+	sign1 := sec1.Sign(m)
+	s = sign1.SerializeToHexStr()
+	var sign2 Sign
+	err = sign2.DeserializeHexStr(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sign1.IsEqual(&sign2) {
+		t.Error("Sign not same")
+	}
+}
+
+func testOrder(t *testing.T, c int) {
+	var curve string
+	var field string
+	if c == CurveFp254BNb {
+		curve = "16798108731015832284940804142231733909759579603404752749028378864165570215949"
+		field = "16798108731015832284940804142231733909889187121439069848933715426072753864723"
+	} else if c == CurveFp382_1 {
+		curve = "5540996953667913971058039301942914304734176495422447785042938606876043190415948413757785063597439175372845535461389"
+		field = "5540996953667913971058039301942914304734176495422447785045292539108217242186829586959562222833658991069414454984723"
+	} else if c == CurveFp382_2 {
+		curve = "5541245505022739011583672869577435255026888277144126952448297309161979278754528049907713682488818304329661351460877"
+		field = "5541245505022739011583672869577435255026888277144126952450651294188487038640194767986566260919128250811286032482323"
+	} else if c == BLS12_381 {
+		curve = "52435875175126190479447740508185965837690552500527637822603658699938581184513"
+		field = "4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787"
+	} else {
+		t.Fatal("bad c", c)
+	}
+	s := GetCurveOrder()
+	if s != curve {
+		t.Errorf("bad curve order\n%s\n%s\n", s, curve)
+	}
+	s = GetFieldOrder()
+	if s != field {
+		t.Errorf("bad field order\n%s\n%s\n", s, field)
+	}
+}
+
+func testDHKeyExchange(t *testing.T) {
+	var sec1, sec2 SecretKey
+	sec1.SetByCSPRNG()
+	sec2.SetByCSPRNG()
+	pub1 := sec1.GetPublicKey()
+	pub2 := sec2.GetPublicKey()
+	out1 := DHKeyExchange(&sec1, pub2)
+	out2 := DHKeyExchange(&sec2, pub1)
+	if !out1.IsEqual(&out2) {
+		t.Errorf("DH key is not equal")
+	}
+}
+
+func testPairing(t *testing.T) {
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	pub := sec.GetPublicKey()
+	m := "abc"
+	sig1 := sec.Sign(m)
+	sig2 := HashAndMapToSignature([]byte(m))
+	if !VerifyPairing(sig1, sig2, pub) {
+		t.Errorf("VerifyPairing")
+	}
+}
+
+func testAggregate(t *testing.T) {
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	pub := sec.GetPublicKey()
+	msgTbl := []string{"abc", "def", "123"}
+	n := len(msgTbl)
+	sigVec := make([]*Sign, n)
+	for i := 0; i < n; i++ {
+		m := msgTbl[i]
+		sigVec[i] = sec.Sign(m)
+	}
+	aggSign := sigVec[0]
+	for i := 1; i < n; i++ {
+		aggSign.Add(sigVec[i])
+	}
+	hashPt := HashAndMapToSignature([]byte(msgTbl[0]))
+	for i := 1; i < n; i++ {
+		hashPt.Add(HashAndMapToSignature([]byte(msgTbl[i])))
+	}
+	if !VerifyPairing(aggSign, hashPt, pub) {
+		t.Errorf("aggregate2")
+	}
+}
+
+func Hash(buf []byte) []byte {
+	if GetOpUnitSize() == 4 {
+		d := sha256.Sum256([]byte(buf))
+		return d[:]
+	}
+	// use SHA512 if bitSize > 256
+	d := sha512.Sum512([]byte(buf))
+	return d[:]
+}
+
+func testHash(t *testing.T) {
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	pub := sec.GetPublicKey()
+	m := "abc"
+	h := Hash([]byte(m))
+	sig1 := sec.Sign(m)
+	sig2 := sec.SignHash(h)
+	if !sig1.IsEqual(sig2) {
+		t.Errorf("SignHash")
+	}
+	if !sig1.Verify(pub, m) {
+		t.Errorf("sig1.Verify")
+	}
+	if !sig2.VerifyHash(pub, h) {
+		t.Errorf("sig2.VerifyHash")
+	}
+}
+
+func testAggregateHashes(t *testing.T) {
+	n := 1000
+	pubVec := make([]PublicKey, n)
+	sigVec := make([]*Sign, n)
+	h := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		sec := new(SecretKey)
+		sec.SetByCSPRNG()
+		pubVec[i] = *sec.GetPublicKey()
+		m := fmt.Sprintf("abc-%d", i)
+		h[i] = Hash([]byte(m))
+		sigVec[i] = sec.SignHash(h[i])
+	}
+	// aggregate sig
+	sig := sigVec[0]
+	for i := 1; i < n; i++ {
+		sig.Add(sigVec[i])
+	}
+	if !sig.VerifyAggregateHashes(pubVec, h) {
+		t.Errorf("sig.VerifyAggregateHashes")
+	}
+}
+
+type SeqRead struct {
+}
+
+func (seq *SeqRead) Read(buf []byte) (int, error) {
+	n := len(buf)
+	for i := 0; i < n; i++ {
+		buf[i] = byte(i)
+	}
+	return n, nil
+}
+
+func testReadRand(t *testing.T) {
+	s1 := new(SeqRead)
+	SetRandFunc(s1)
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	buf := sec.GetLittleEndian()
+	fmt.Printf("(SeqRead) buf=%x\n", buf)
+	for i := 0; i < len(buf)-1; i++ {
+		// ommit buf[len(buf) - 1] because it may be masked
+		if buf[i] != byte(i) {
+			t.Fatal("buf")
+		}
+	}
+	SetRandFunc(rand.Reader)
+	sec.SetByCSPRNG()
+	buf = sec.GetLittleEndian()
+	fmt.Printf("(rand.Reader) buf=%x\n", buf)
+	SetRandFunc(nil)
+	sec.SetByCSPRNG()
+	buf = sec.GetLittleEndian()
+	fmt.Printf("(default) buf=%x\n", buf)
+}
+
+func test(t *testing.T, c int) {
+	err := Init(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unitN = GetOpUnitSize()
+	t.Logf("unitN=%d\n", unitN)
+	testReadRand(t)
+	testPre(t)
+	testRecoverSecretKey(t)
+	testAdd(t)
+	testSign(t)
+	testPop(t)
+	testData(t)
+	testStringConversion(t)
+	testOrder(t, c)
+	testDHKeyExchange(t)
+	testSerializeToHexStr(t)
+	testPairing(t)
+	testAggregate(t)
+	testHash(t)
+	testAggregateHashes(t)
+}
+
+func TestMain(t *testing.T) {
+	t.Logf("GetMaxOpUnitSize() = %d\n", GetMaxOpUnitSize())
+	t.Log("CurveFp254BNb")
+	test(t, CurveFp254BNb)
+	if GetMaxOpUnitSize() == 6 {
+		if GetFrUnitSize() == 6 {
+			t.Log("CurveFp382_1")
+			test(t, CurveFp382_1)
+		}
+		t.Log("BLS12_381")
+		test(t, BLS12_381)
+	}
+}
+
+// Benchmarks
+
+var curve = CurveFp382_1
+
+//var curve = CurveFp254BNb
+
+func BenchmarkPubkeyFromSeckey(b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	for n := 0; n < b.N; n++ {
+		sec.SetByCSPRNG()
+		b.StartTimer()
+		sec.GetPublicKey()
+		b.StopTimer()
+	}
+}
+
+func BenchmarkSigning(b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	for n := 0; n < b.N; n++ {
+		sec.SetByCSPRNG()
+		b.StartTimer()
+		sec.Sign(strconv.Itoa(n))
+		b.StopTimer()
+	}
+}
+
+func BenchmarkValidation(b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	for n := 0; n < b.N; n++ {
+		sec.SetByCSPRNG()
+		pub := sec.GetPublicKey()
+		m := strconv.Itoa(n)
+		sig := sec.Sign(m)
+		b.StartTimer()
+		sig.Verify(pub, m)
+		b.StopTimer()
+	}
+}
+
+func benchmarkDeriveSeckeyShare(k int, b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	msk := sec.GetMasterSecretKey(k)
+	var id ID
+	for n := 0; n < b.N; n++ {
+		err = id.SetLittleEndian([]byte{1, 2, 3, 4, 5, byte(n)})
+		if err != nil {
+			b.Error(err)
+		}
+		b.StartTimer()
+		err := sec.Set(msk, &id)
+		b.StopTimer()
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+//func BenchmarkDeriveSeckeyShare100(b *testing.B)  { benchmarkDeriveSeckeyShare(100, b) }
+//func BenchmarkDeriveSeckeyShare200(b *testing.B)  { benchmarkDeriveSeckeyShare(200, b) }
+func BenchmarkDeriveSeckeyShare500(b *testing.B) { benchmarkDeriveSeckeyShare(500, b) }
+
+//func BenchmarkDeriveSeckeyShare1000(b *testing.B) { benchmarkDeriveSeckeyShare(1000, b) }
+
+func benchmarkRecoverSeckey(k int, b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	msk := sec.GetMasterSecretKey(k)
+
+	// derive n shares
+	n := k
+	secVec := make([]SecretKey, n)
+	idVec := make([]ID, n)
+	for i := 0; i < n; i++ {
+		err := idVec[i].SetLittleEndian([]byte{1, 2, 3, 4, 5, byte(i)})
+		if err != nil {
+			b.Error(err)
+		}
+		err = secVec[i].Set(msk, &idVec[i])
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	// recover from secVec and idVec
+	var sec2 SecretKey
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		err := sec2.Recover(secVec, idVec)
+		if err != nil {
+			b.Errorf("%s\n", err)
+		}
+	}
+}
+
+func BenchmarkRecoverSeckey100(b *testing.B)  { benchmarkRecoverSeckey(100, b) }
+func BenchmarkRecoverSeckey200(b *testing.B)  { benchmarkRecoverSeckey(200, b) }
+func BenchmarkRecoverSeckey500(b *testing.B)  { benchmarkRecoverSeckey(500, b) }
+func BenchmarkRecoverSeckey1000(b *testing.B) { benchmarkRecoverSeckey(1000, b) }
+
+func benchmarkRecoverSignature(k int, b *testing.B) {
+	b.StopTimer()
+	err := Init(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var sec SecretKey
+	sec.SetByCSPRNG()
+	msk := sec.GetMasterSecretKey(k)
+
+	// derive n shares
+	n := k
+	idVec := make([]ID, n)
+	secVec := make([]SecretKey, n)
+	signVec := make([]Sign, n)
+	for i := 0; i < n; i++ {
+		err := idVec[i].SetLittleEndian([]byte{1, 2, 3, 4, 5, byte(i)})
+		if err != nil {
+			b.Error(err)
+		}
+		err = secVec[i].Set(msk, &idVec[i])
+		if err != nil {
+			b.Error(err)
+		}
+		signVec[i] = *secVec[i].Sign("test message")
+	}
+
+	// recover signature
+	var sig Sign
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		err := sig.Recover(signVec, idVec)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkRecoverSignature100(b *testing.B)  { benchmarkRecoverSignature(100, b) }
+func BenchmarkRecoverSignature200(b *testing.B)  { benchmarkRecoverSignature(200, b) }
+func BenchmarkRecoverSignature500(b *testing.B)  { benchmarkRecoverSignature(500, b) }
+func BenchmarkRecoverSignature1000(b *testing.B) { benchmarkRecoverSignature(1000, b) }

--- a/crypto/bls/bls/callback.go
+++ b/crypto/bls/bls/callback.go
@@ -1,0 +1,12 @@
+package bls
+
+/*
+// exported from bls.go
+unsigned int wrapReadRandGo(void *buf, unsigned int n);
+int wrapReadRandCgo(void *self, void *buf, unsigned int n)
+{
+	(void)self;
+	return wrapReadRandGo(buf, n);
+}
+*/
+import "C"

--- a/crypto/bls/bls/mcl.go
+++ b/crypto/bls/bls/mcl.go
@@ -1,0 +1,646 @@
+package bls
+
+/*
+#cgo bn256 CFLAGS:-DMCLBN_FP_UNIT_SIZE=4
+#cgo bn384 CFLAGS:-DMCLBN_FP_UNIT_SIZE=6
+#cgo bn384_256 CFLAGS:-DMCLBN_FP_UNIT_SIZE=6 -DMCLBN_FR_UNIT_SIZE=4
+#include <mcl/bn.h>
+
+*/
+import "C"
+import "fmt"
+import "unsafe"
+
+// CurveFp254BNb -- 254 bit curve
+const CurveFp254BNb = C.mclBn_CurveFp254BNb
+
+// CurveFp382_1 -- 382 bit curve 1
+const CurveFp382_1 = C.mclBn_CurveFp382_1
+
+// CurveFp382_2 -- 382 bit curve 2
+const CurveFp382_2 = C.mclBn_CurveFp382_2
+
+// BLS12_381
+const BLS12_381 = C.MCL_BLS12_381
+
+// IoSerializeHexStr
+const IoSerializeHexStr = C.MCLBN_IO_SERIALIZE_HEX_STR
+
+// GetFrUnitSize() --
+func GetFrUnitSize() int {
+	return int(C.MCLBN_FR_UNIT_SIZE)
+}
+
+// GetFpUnitSize() --
+// same as GetMaxOpUnitSize()
+func GetFpUnitSize() int {
+	return int(C.MCLBN_FP_UNIT_SIZE)
+}
+
+// GetMaxOpUnitSize --
+func GetMaxOpUnitSize() int {
+	return int(C.MCLBN_FP_UNIT_SIZE)
+}
+
+// GetOpUnitSize --
+// the length of Fr is GetOpUnitSize() * 8 bytes
+func GetOpUnitSize() int {
+	return int(C.mclBn_getOpUnitSize())
+}
+
+// GetCurveOrder --
+// return the order of G1
+func GetCurveOrder() string {
+	buf := make([]byte, 1024)
+	// #nosec
+	n := C.mclBn_getCurveOrder((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+	if n == 0 {
+		panic("implementation err. size of buf is small")
+	}
+	return string(buf[:n])
+}
+
+// GetFieldOrder --
+// return the characteristic of the field where a curve is defined
+func GetFieldOrder() string {
+	buf := make([]byte, 1024)
+	// #nosec
+	n := C.mclBn_getFieldOrder((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+	if n == 0 {
+		panic("implementation err. size of buf is small")
+	}
+	return string(buf[:n])
+}
+
+// Fr --
+type Fr struct {
+	v C.mclBnFr
+}
+
+// getPointer --
+func (x *Fr) getPointer() (p *C.mclBnFr) {
+	// #nosec
+	return (*C.mclBnFr)(unsafe.Pointer(x))
+}
+
+// Clear --
+func (x *Fr) Clear() {
+	// #nosec
+	C.mclBnFr_clear(x.getPointer())
+}
+
+// SetInt64 --
+func (x *Fr) SetInt64(v int64) {
+	// #nosec
+	C.mclBnFr_setInt(x.getPointer(), C.int64_t(v))
+}
+
+// SetString --
+func (x *Fr) SetString(s string, base int) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.mclBnFr_setStr(x.getPointer(), (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), C.int(base))
+	if err != 0 {
+		return fmt.Errorf("err mclBnFr_setStr %x", err)
+	}
+	return nil
+}
+
+// Deserialize --
+func (x *Fr) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.mclBnFr_deserialize(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err mclBnFr_deserialize %x", buf)
+	}
+	return nil
+}
+
+// SetLittleEndian --
+func (x *Fr) SetLittleEndian(buf []byte) error {
+	// #nosec
+	err := C.mclBnFr_setLittleEndian(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err mclBnFr_setLittleEndian %x", err)
+	}
+	return nil
+}
+
+// IsEqual --
+func (x *Fr) IsEqual(rhs *Fr) bool {
+	return C.mclBnFr_isEqual(x.getPointer(), rhs.getPointer()) == 1
+}
+
+// IsZero --
+func (x *Fr) IsZero() bool {
+	return C.mclBnFr_isZero(x.getPointer()) == 1
+}
+
+// IsOne --
+func (x *Fr) IsOne() bool {
+	return C.mclBnFr_isOne(x.getPointer()) == 1
+}
+
+// SetByCSPRNG --
+func (x *Fr) SetByCSPRNG() {
+	err := C.mclBnFr_setByCSPRNG(x.getPointer())
+	if err != 0 {
+		panic("err mclBnFr_setByCSPRNG")
+	}
+}
+
+// SetHashOf --
+func (x *Fr) SetHashOf(buf []byte) bool {
+	// #nosec
+	return C.mclBnFr_setHashOf(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf))) == 0
+}
+
+// GetString --
+func (x *Fr) GetString(base int) string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnFr_getStr((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), x.getPointer(), C.int(base))
+	if n == 0 {
+		panic("err mclBnFr_getStr")
+	}
+	return string(buf[:n])
+}
+
+// Serialize --
+func (x *Fr) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnFr_serialize(unsafe.Pointer(&buf[0]), C.size_t(len(buf)), x.getPointer())
+	if n == 0 {
+		panic("err mclBnFr_serialize")
+	}
+	return buf[:n]
+}
+
+// FrNeg --
+func FrNeg(out *Fr, x *Fr) {
+	C.mclBnFr_neg(out.getPointer(), x.getPointer())
+}
+
+// FrInv --
+func FrInv(out *Fr, x *Fr) {
+	C.mclBnFr_inv(out.getPointer(), x.getPointer())
+}
+
+// FrAdd --
+func FrAdd(out *Fr, x *Fr, y *Fr) {
+	C.mclBnFr_add(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// FrSub --
+func FrSub(out *Fr, x *Fr, y *Fr) {
+	C.mclBnFr_sub(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// FrMul --
+func FrMul(out *Fr, x *Fr, y *Fr) {
+	C.mclBnFr_mul(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// FrDiv --
+func FrDiv(out *Fr, x *Fr, y *Fr) {
+	C.mclBnFr_div(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G1 --
+type G1 struct {
+	v C.mclBnG1
+}
+
+// getPointer --
+func (x *G1) getPointer() (p *C.mclBnG1) {
+	// #nosec
+	return (*C.mclBnG1)(unsafe.Pointer(x))
+}
+
+// Clear --
+func (x *G1) Clear() {
+	// #nosec
+	C.mclBnG1_clear(x.getPointer())
+}
+
+// SetString --
+func (x *G1) SetString(s string, base int) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.mclBnG1_setStr(x.getPointer(), (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), C.int(base))
+	if err != 0 {
+		return fmt.Errorf("err mclBnG1_setStr %x", err)
+	}
+	return nil
+}
+
+// Deserialize --
+func (x *G1) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.mclBnG1_deserialize(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err mclBnG1_deserialize %x", buf)
+	}
+	return nil
+}
+
+// IsEqual --
+func (x *G1) IsEqual(rhs *G1) bool {
+	return C.mclBnG1_isEqual(x.getPointer(), rhs.getPointer()) == 1
+}
+
+// IsZero --
+func (x *G1) IsZero() bool {
+	return C.mclBnG1_isZero(x.getPointer()) == 1
+}
+
+// HashAndMapTo --
+func (x *G1) HashAndMapTo(buf []byte) error {
+	// #nosec
+	err := C.mclBnG1_hashAndMapTo(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err mclBnG1_hashAndMapTo %x", err)
+	}
+	return nil
+}
+
+// GetString --
+func (x *G1) GetString(base int) string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnG1_getStr((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), x.getPointer(), C.int(base))
+	if n == 0 {
+		panic("err mclBnG1_getStr")
+	}
+	return string(buf[:n])
+}
+
+// Serialize --
+func (x *G1) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnG1_serialize(unsafe.Pointer(&buf[0]), C.size_t(len(buf)), x.getPointer())
+	if n == 0 {
+		panic("err mclBnG1_serialize")
+	}
+	return buf[:n]
+}
+
+// G1Neg --
+func G1Neg(out *G1, x *G1) {
+	C.mclBnG1_neg(out.getPointer(), x.getPointer())
+}
+
+// G1Dbl --
+func G1Dbl(out *G1, x *G1) {
+	C.mclBnG1_dbl(out.getPointer(), x.getPointer())
+}
+
+// G1Add --
+func G1Add(out *G1, x *G1, y *G1) {
+	C.mclBnG1_add(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G1Sub --
+func G1Sub(out *G1, x *G1, y *G1) {
+	C.mclBnG1_sub(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G1Mul --
+func G1Mul(out *G1, x *G1, y *Fr) {
+	C.mclBnG1_mul(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G1MulCT -- constant time (depending on bit lengh of y)
+func G1MulCT(out *G1, x *G1, y *Fr) {
+	C.mclBnG1_mulCT(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G2 --
+type G2 struct {
+	v C.mclBnG2
+}
+
+// getPointer --
+func (x *G2) getPointer() (p *C.mclBnG2) {
+	// #nosec
+	return (*C.mclBnG2)(unsafe.Pointer(x))
+}
+
+// Clear --
+func (x *G2) Clear() {
+	// #nosec
+	C.mclBnG2_clear(x.getPointer())
+}
+
+// SetString --
+func (x *G2) SetString(s string, base int) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.mclBnG2_setStr(x.getPointer(), (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), C.int(base))
+	if err != 0 {
+		return fmt.Errorf("err mclBnG2_setStr %x", err)
+	}
+	return nil
+}
+
+// Deserialize --
+func (x *G2) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.mclBnG2_deserialize(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err mclBnG2_deserialize %x", buf)
+	}
+	return nil
+}
+
+// IsEqual --
+func (x *G2) IsEqual(rhs *G2) bool {
+	return C.mclBnG2_isEqual(x.getPointer(), rhs.getPointer()) == 1
+}
+
+// IsZero --
+func (x *G2) IsZero() bool {
+	return C.mclBnG2_isZero(x.getPointer()) == 1
+}
+
+// HashAndMapTo --
+func (x *G2) HashAndMapTo(buf []byte) error {
+	// #nosec
+	err := C.mclBnG2_hashAndMapTo(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err != 0 {
+		return fmt.Errorf("err mclBnG2_hashAndMapTo %x", err)
+	}
+	return nil
+}
+
+// GetString --
+func (x *G2) GetString(base int) string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnG2_getStr((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), x.getPointer(), C.int(base))
+	if n == 0 {
+		panic("err mclBnG2_getStr")
+	}
+	return string(buf[:n])
+}
+
+// Serialize --
+func (x *G2) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnG2_serialize(unsafe.Pointer(&buf[0]), C.size_t(len(buf)), x.getPointer())
+	if n == 0 {
+		panic("err mclBnG2_serialize")
+	}
+	return buf[:n]
+}
+
+// G2Neg --
+func G2Neg(out *G2, x *G2) {
+	C.mclBnG2_neg(out.getPointer(), x.getPointer())
+}
+
+// G2Dbl --
+func G2Dbl(out *G2, x *G2) {
+	C.mclBnG2_dbl(out.getPointer(), x.getPointer())
+}
+
+// G2Add --
+func G2Add(out *G2, x *G2, y *G2) {
+	C.mclBnG2_add(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G2Sub --
+func G2Sub(out *G2, x *G2, y *G2) {
+	C.mclBnG2_sub(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// G2Mul --
+func G2Mul(out *G2, x *G2, y *Fr) {
+	C.mclBnG2_mul(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GT --
+type GT struct {
+	v C.mclBnGT
+}
+
+// getPointer --
+func (x *GT) getPointer() (p *C.mclBnGT) {
+	// #nosec
+	return (*C.mclBnGT)(unsafe.Pointer(x))
+}
+
+// Clear --
+func (x *GT) Clear() {
+	// #nosec
+	C.mclBnGT_clear(x.getPointer())
+}
+
+// SetInt64 --
+func (x *GT) SetInt64(v int64) {
+	// #nosec
+	C.mclBnGT_setInt(x.getPointer(), C.int64_t(v))
+}
+
+// SetString --
+func (x *GT) SetString(s string, base int) error {
+	buf := []byte(s)
+	// #nosec
+	err := C.mclBnGT_setStr(x.getPointer(), (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), C.int(base))
+	if err != 0 {
+		return fmt.Errorf("err mclBnGT_setStr %x", err)
+	}
+	return nil
+}
+
+// Deserialize --
+func (x *GT) Deserialize(buf []byte) error {
+	// #nosec
+	err := C.mclBnGT_deserialize(x.getPointer(), unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+	if err == 0 {
+		return fmt.Errorf("err mclBnGT_deserialize %x", buf)
+	}
+	return nil
+}
+
+// IsEqual --
+func (x *GT) IsEqual(rhs *GT) bool {
+	return C.mclBnGT_isEqual(x.getPointer(), rhs.getPointer()) == 1
+}
+
+// IsZero --
+func (x *GT) IsZero() bool {
+	return C.mclBnGT_isZero(x.getPointer()) == 1
+}
+
+// IsOne --
+func (x *GT) IsOne() bool {
+	return C.mclBnGT_isOne(x.getPointer()) == 1
+}
+
+// GetString --
+func (x *GT) GetString(base int) string {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnGT_getStr((*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)), x.getPointer(), C.int(base))
+	if n == 0 {
+		panic("err mclBnGT_getStr")
+	}
+	return string(buf[:n])
+}
+
+// Serialize --
+func (x *GT) Serialize() []byte {
+	buf := make([]byte, 2048)
+	// #nosec
+	n := C.mclBnGT_serialize(unsafe.Pointer(&buf[0]), C.size_t(len(buf)), x.getPointer())
+	if n == 0 {
+		panic("err mclBnGT_serialize")
+	}
+	return buf[:n]
+}
+
+// GTNeg --
+func GTNeg(out *GT, x *GT) {
+	C.mclBnGT_neg(out.getPointer(), x.getPointer())
+}
+
+// GTInv --
+func GTInv(out *GT, x *GT) {
+	C.mclBnGT_inv(out.getPointer(), x.getPointer())
+}
+
+// GTAdd --
+func GTAdd(out *GT, x *GT, y *GT) {
+	C.mclBnGT_add(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GTSub --
+func GTSub(out *GT, x *GT, y *GT) {
+	C.mclBnGT_sub(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GTMul --
+func GTMul(out *GT, x *GT, y *GT) {
+	C.mclBnGT_mul(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GTDiv --
+func GTDiv(out *GT, x *GT, y *GT) {
+	C.mclBnGT_div(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GTPow --
+func GTPow(out *GT, x *GT, y *Fr) {
+	C.mclBnGT_pow(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// Pairing --
+func Pairing(out *GT, x *G1, y *G2) {
+	C.mclBn_pairing(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// FinalExp --
+func FinalExp(out *GT, x *GT) {
+	C.mclBn_finalExp(out.getPointer(), x.getPointer())
+}
+
+// MillerLoop --
+func MillerLoop(out *GT, x *G1, y *G2) {
+	C.mclBn_millerLoop(out.getPointer(), x.getPointer(), y.getPointer())
+}
+
+// GetUint64NumToPrecompute --
+func GetUint64NumToPrecompute() int {
+	return int(C.mclBn_getUint64NumToPrecompute())
+}
+
+// PrecomputeG2 --
+func PrecomputeG2(Qbuf []uint64, Q *G2) {
+	// #nosec
+	C.mclBn_precomputeG2((*C.uint64_t)(unsafe.Pointer(&Qbuf[0])), Q.getPointer())
+}
+
+// PrecomputedMillerLoop --
+func PrecomputedMillerLoop(out *GT, P *G1, Qbuf []uint64) {
+	// #nosec
+	C.mclBn_precomputedMillerLoop(out.getPointer(), P.getPointer(), (*C.uint64_t)(unsafe.Pointer(&Qbuf[0])))
+}
+
+// PrecomputedMillerLoop2 --
+func PrecomputedMillerLoop2(out *GT, P1 *G1, Q1buf []uint64, P2 *G1, Q2buf []uint64) {
+	// #nosec
+	C.mclBn_precomputedMillerLoop2(out.getPointer(), P1.getPointer(), (*C.uint64_t)(unsafe.Pointer(&Q1buf[0])), P1.getPointer(), (*C.uint64_t)(unsafe.Pointer(&Q1buf[0])))
+}
+
+// FrEvaluatePolynomial -- y = c[0] + c[1] * x + c[2] * x^2 + ...
+func FrEvaluatePolynomial(y *Fr, c []Fr, x *Fr) error {
+	// #nosec
+	err := C.mclBn_FrEvaluatePolynomial(y.getPointer(), (*C.mclBnFr)(unsafe.Pointer(&c[0])), (C.size_t)(len(c)), x.getPointer())
+	if err != 0 {
+		return fmt.Errorf("err mclBn_FrEvaluatePolynomial")
+	}
+	return nil
+}
+
+// G1EvaluatePolynomial -- y = c[0] + c[1] * x + c[2] * x^2 + ...
+func G1EvaluatePolynomial(y *G1, c []G1, x *Fr) error {
+	// #nosec
+	err := C.mclBn_G1EvaluatePolynomial(y.getPointer(), (*C.mclBnG1)(unsafe.Pointer(&c[0])), (C.size_t)(len(c)), x.getPointer())
+	if err != 0 {
+		return fmt.Errorf("err mclBn_G1EvaluatePolynomial")
+	}
+	return nil
+}
+
+// G2EvaluatePolynomial -- y = c[0] + c[1] * x + c[2] * x^2 + ...
+func G2EvaluatePolynomial(y *G2, c []G2, x *Fr) error {
+	// #nosec
+	err := C.mclBn_G2EvaluatePolynomial(y.getPointer(), (*C.mclBnG2)(unsafe.Pointer(&c[0])), (C.size_t)(len(c)), x.getPointer())
+	if err != 0 {
+		return fmt.Errorf("err mclBn_G2EvaluatePolynomial")
+	}
+	return nil
+}
+
+// FrLagrangeInterpolation --
+func FrLagrangeInterpolation(out *Fr, xVec []Fr, yVec []Fr) error {
+	if len(xVec) != len(yVec) {
+		return fmt.Errorf("err FrLagrangeInterpolation:bad size")
+	}
+	// #nosec
+	err := C.mclBn_FrLagrangeInterpolation(out.getPointer(), (*C.mclBnFr)(unsafe.Pointer(&xVec[0])), (*C.mclBnFr)(unsafe.Pointer(&yVec[0])), (C.size_t)(len(xVec)))
+	if err != 0 {
+		return fmt.Errorf("err FrLagrangeInterpolation")
+	}
+	return nil
+}
+
+// G1LagrangeInterpolation --
+func G1LagrangeInterpolation(out *G1, xVec []Fr, yVec []G1) error {
+	if len(xVec) != len(yVec) {
+		return fmt.Errorf("err G1LagrangeInterpolation:bad size")
+	}
+	// #nosec
+	err := C.mclBn_G1LagrangeInterpolation(out.getPointer(), (*C.mclBnFr)(unsafe.Pointer(&xVec[0])), (*C.mclBnG1)(unsafe.Pointer(&yVec[0])), (C.size_t)(len(xVec)))
+	if err != 0 {
+		return fmt.Errorf("err G1LagrangeInterpolation")
+	}
+	return nil
+}
+
+// G2LagrangeInterpolation --
+func G2LagrangeInterpolation(out *G2, xVec []Fr, yVec []G2) error {
+	if len(xVec) != len(yVec) {
+		return fmt.Errorf("err G2LagrangeInterpolation:bad size")
+	}
+	// #nosec
+	err := C.mclBn_G2LagrangeInterpolation(out.getPointer(), (*C.mclBnFr)(unsafe.Pointer(&xVec[0])), (*C.mclBnG2)(unsafe.Pointer(&yVec[0])), (C.size_t)(len(xVec)))
+	if err != 0 {
+		return fmt.Errorf("err G2LagrangeInterpolation")
+	}
+	return nil
+}

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -1,0 +1,52 @@
+package bls
+
+import (
+	"sync"
+	"testing"
+	kilicBls "github.com/kilic/bls12-381"
+)
+
+func TestStressLargetSet(t *testing.T) {
+
+	var privs []PrivKeyBls
+	var pubs []PubKeyBls
+
+	testKeyCount := 100
+
+	//Initialzie large set keys
+	for i := 0; i < testKeyCount; i++ {
+		priv, pub := GenerateKey()
+		privs = append(privs, priv)
+		pubs = append(pubs, pub)
+	}
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < testKeyCount-1; i++ {
+		for j := i + 1; j < testKeyCount-1; j++ {
+			wg.Add(1)
+			testMsg := []byte{0x4d, 0x5a, 0x00, 0x90}
+			sig, err := privs[i].Sign(testMsg)
+			go func(x, y int, sig []byte) {
+				if err != nil {
+					panic("T1")
+				}
+				if pubs[x].VerifyBytes(testMsg, sig) != true {
+					panic("T2")
+				}
+				if pubs[y].VerifyBytes(testMsg, sig) == true {
+					panic("T3")
+				}
+
+				wg.Done()
+				// assert.NoError(t, err)
+				// assert.True(t, pubs[x].VerifyBytes(testMsg, sig))
+				// assert.False(t, pubs[y].VerifyBytes(testMsg, sig))
+			}(i, j, sig)
+		}
+	}
+	wg.Wait()
+}
+
+func TestSameOutput(t *testing.T) {
+	kilicBls.blssig.
+}

--- a/crypto/bls/codec.go
+++ b/crypto/bls/codec.go
@@ -1,0 +1,21 @@
+package bls
+
+import (
+	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/crypto"
+)
+
+const (
+	PrivKeyAminoName = "tendermint/PrivKeyBls12_381"
+	PubKeyAminoName  = "tendermint/PubKeyBls12_381"
+)
+
+var cdc = amino.NewCodec()
+
+func init() {
+	cdc.RegisterInterface((*crypto.PrivKey)(nil), nil)
+	cdc.RegisterConcrete(PrivKeyBls{}, PrivKeyAminoName, nil)
+
+	cdc.RegisterInterface((*crypto.PubKey)(nil), nil)
+	cdc.RegisterConcrete(PubKeyBls{}, PubKeyAminoName, nil)
+}

--- a/crypto/encoding/amino/amino.go
+++ b/crypto/encoding/amino/amino.go
@@ -3,6 +3,8 @@ package cryptoAmino
 import (
 	"reflect"
 
+	"github.com/tendermint/tendermint/crypto/bls"
+
 	amino "github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -16,7 +18,7 @@ var cdc = amino.NewCodec()
 // to their registered amino names. This should eventually be handled
 // by amino. Example usage:
 // nameTable[reflect.TypeOf(ed25519.PubKeyEd25519{})] = ed25519.PubKeyAminoName
-var nameTable = make(map[reflect.Type]string, 3)
+var nameTable = make(map[reflect.Type]string, 4)
 
 func init() {
 	// NOTE: It's important that there be no conflicts here,
@@ -32,6 +34,7 @@ func init() {
 	nameTable[reflect.TypeOf(ed25519.PubKeyEd25519{})] = ed25519.PubKeyAminoName
 	nameTable[reflect.TypeOf(secp256k1.PubKeySecp256k1{})] = secp256k1.PubKeyAminoName
 	nameTable[reflect.TypeOf(multisig.PubKeyMultisigThreshold{})] = multisig.PubKeyMultisigThresholdAminoRoute
+	nameTable[reflect.TypeOf(bls.PubKeyBls{})] = bls.PubKeyAminoName
 }
 
 // PubkeyAminoName returns the amino route of a pubkey
@@ -52,12 +55,16 @@ func RegisterAmino(cdc *amino.Codec) {
 		secp256k1.PubKeyAminoName, nil)
 	cdc.RegisterConcrete(multisig.PubKeyMultisigThreshold{},
 		multisig.PubKeyMultisigThresholdAminoRoute, nil)
+	cdc.RegisterConcrete(bls.PubKeyBls{},
+		bls.PubKeyAminoName, nil)
 
 	cdc.RegisterInterface((*crypto.PrivKey)(nil), nil)
 	cdc.RegisterConcrete(ed25519.PrivKeyEd25519{},
 		ed25519.PrivKeyAminoName, nil)
 	cdc.RegisterConcrete(secp256k1.PrivKeySecp256k1{},
 		secp256k1.PrivKeyAminoName, nil)
+	cdc.RegisterConcrete(bls.PrivKeyBls{},
+		bls.PrivKeyAminoName, nil)
 }
 
 func PrivKeyFromBytes(privKeyBytes []byte) (privKey crypto.PrivKey, err error) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@ require (
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/gorilla/websocket v1.2.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/herumi/bls v0.0.0-20191115023943-607fd587494f
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kilic/bls12-381 v0.0.0-20191103193557-038659eaa189
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.1
 	github.com/magiconair/properties v1.8.0
@@ -39,6 +41,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/tendermint/go-amino v0.14.1
 	github.com/tendermint/tm-db v0.1.1
+	go.dedis.ch/kyber/v4 v4.0.0-pre1
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	google.golang.org/grpc v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTM
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/herumi/bls v0.0.0-20191115023943-607fd587494f h1:RacP4OBteYrGpuXFAscwIOi8OTFLZp7R7AgocNV/hRk=
+github.com/herumi/bls v0.0.0-20191115023943-607fd587494f/go.mod h1:i4wRNUUFF1nNmYFHM9UDl13MGoxEQkMVCLAd82qZz4s=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -58,6 +60,8 @@ github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
+github.com/kilic/bls12-381 v0.0.0-20191103193557-038659eaa189 h1:WRnsL0VkrblaNFSVDzLg022qn84Vr7M+DR3OeKwhdb0=
+github.com/kilic/bls12-381 v0.0.0-20191103193557-038659eaa189/go.mod h1:INznczsRc7ASFbWFUI9GnIvpi9s2FhenKE+24rdTmBQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
@@ -119,9 +123,17 @@ github.com/tendermint/tm-db v0.0.0-20190731085305-94017c88bf1d h1:yCHL2COLGLNfb4
 github.com/tendermint/tm-db v0.0.0-20190731085305-94017c88bf1d/go.mod h1:0cPKWu2Mou3IlxecH+MEUSYc1Ch537alLe6CpFrKzgw=
 github.com/tendermint/tm-db v0.1.1 h1:G3Xezy3sOk9+ekhjZ/kjArYIs1SmwV+1OUgNkj7RgV0=
 github.com/tendermint/tm-db v0.1.1/go.mod h1:0cPKWu2Mou3IlxecH+MEUSYc1Ch537alLe6CpFrKzgw=
+go.dedis.ch/fixbuf v1.0.3 h1:hGcV9Cd/znUxlusJ64eAlExS+5cJDIyTyEG+otu5wQs=
+go.dedis.ch/fixbuf v1.0.3/go.mod h1:yzJMt34Wa5xD37V5RTdmp38cz3QhMagdGoem9anUalw=
+go.dedis.ch/kyber/v3 v3.0.4/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhsQ=
+go.dedis.ch/kyber/v4 v4.0.0-pre1 h1:1f5OPESkyxK6kPaCSV3J9BlpnoysIpbGLNujX9Ov8m4=
+go.dedis.ch/kyber/v4 v4.0.0-pre1/go.mod h1:cFStqSeD4d3Y7mal8kCRSq7I7QPeTBA0f5cRl1pqEWA=
+go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRLo=
+go.dedis.ch/protobuf v1.0.7/go.mod h1:pv5ysfkDX/EawiPqcW3ikOxsL5t+BqnV6xHSmE79KI4=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -135,8 +147,11 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339 h1:zSqWKgm/o7HAnlAzBQ+aetp9fpuyytsXnKA8eiLHYQM=
+golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -156,4 +171,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/p2p/key.go
+++ b/p2p/key.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/tendermint/tendermint/crypto/bls"
+
 	"github.com/tendermint/tendermint/crypto"
-	"github.com/tendermint/tendermint/crypto/ed25519"
+
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
@@ -71,7 +73,7 @@ func LoadNodeKey(filePath string) (*NodeKey, error) {
 }
 
 func genNodeKey(filePath string) (*NodeKey, error) {
-	privKey := ed25519.GenPrivKey()
+	privKey, _ := bls.GenerateKey()
 	nodeKey := &NodeKey{
 		PrivKey: privKey,
 	}

--- a/privval/file.go
+++ b/privval/file.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
-	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/crypto/bls"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -142,7 +142,7 @@ type FilePV struct {
 // GenFilePV generates a new validator with randomly generated private key
 // and sets the filePaths, but does not call Save().
 func GenFilePV(keyFilePath, stateFilePath string) *FilePV {
-	privKey := ed25519.GenPrivKey()
+	privKey, _ := bls.GenerateKey()
 
 	return &FilePV{
 		Key: FilePVKey{

--- a/scripts/get_tools.sh
+++ b/scripts/get_tools.sh
@@ -48,6 +48,27 @@ installFromGithub() {
 	echo ""
 }
 
+
+makeInstallFromGithub() {
+	repo=$1
+	commit=$2
+	# optional
+	optionalEnv=$3
+
+	echo "--> Make Installing $repo ($commit)..."
+	if [ ! -d "$repo" ]; then
+		mkdir -p "$repo"
+		git clone "https://github.com/$repo.git" "$repo"
+	fi
+	pushd "$repo" && \
+		git fetch origin && \
+		git checkout -q "$commit" && \
+		make $optionalEnv install && \
+		popd || exit 1
+	echo "--> Done"
+	echo ""
+}
+
 ######################## DEVELOPER TOOLS #####################################
 installFromGithub gogo/protobuf 61dbc136cf5d2f08d68a011382652244990a53a9 protoc-gen-gogo
 
@@ -64,3 +85,15 @@ installFromGithub golangci/golangci-lint 7b2421d55194c9dc385eff7720a037aa9244ca3
 installFromGithub petermattis/goid b0b1615b78e5ee59739545bb38426383b2cda4c9
 installFromGithub sasha-s/go-deadlock d68e2bc52ae3291765881b9056f2c1527f245f1e
 go get golang.org/x/tools/cmd/goimports
+
+# used to bls-signature
+#Don't use GMP, because it cause need to GPL License : https://github.com/herumi/bls/issues/19
+makeInstallFromGithub herumi/mcl 0dfad750693baa7fc89c06c4278972ac11aecf72 MCL_USE_GMP=0
+makeInstallFromGithub herumi/bls 607fd587494f75edd7239b132fee172f0dbcd86a
+
+# If Mac environment, OpenSSL installation path is different
+CHECK_OS="`uname -s`"
+if [[ "$CHECK_OS" = "Darwin"* ]]; then
+	macCryptoLIBPath=/usr/local/opt/openssl/lib
+	cp -a $macCryptoLIBPath/libcrypto.a /usr/local/lib/
+fi

--- a/types/params.go
+++ b/types/params.go
@@ -79,7 +79,7 @@ func DefaultEvidenceParams() EvidenceParams {
 // DefaultValidatorParams returns a default ValidatorParams, which allows
 // only ed25519 pubkeys.
 func DefaultValidatorParams() ValidatorParams {
-	return ValidatorParams{[]string{ABCIPubKeyTypeEd25519}}
+	return ValidatorParams{[]string{ABCIPubKeyTypeBLS}}
 }
 
 func (params *ValidatorParams) IsValidPubkeyType(pubkeyType string) bool {

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -7,6 +7,7 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/bls"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
@@ -22,12 +23,14 @@ const (
 const (
 	ABCIPubKeyTypeEd25519   = "ed25519"
 	ABCIPubKeyTypeSecp256k1 = "secp256k1"
+	ABCIPubKeyTypeBLS       = "bls"
 )
 
 // TODO: Make non-global by allowing for registration of more pubkey types
 var ABCIPubKeyTypesToAminoNames = map[string]string{
 	ABCIPubKeyTypeEd25519:   ed25519.PubKeyAminoName,
 	ABCIPubKeyTypeSecp256k1: secp256k1.PubKeyAminoName,
+	ABCIPubKeyTypeBLS:       bls.PubKeyAminoName,
 }
 
 //-------------------------------------------------------
@@ -108,6 +111,12 @@ func (tm2pb) PubKey(pubKey crypto.PubKey) abci.PubKey {
 		return abci.PubKey{
 			Type: ABCIPubKeyTypeSecp256k1,
 			Data: pk[:],
+		}
+	case bls.PubKeyBls:
+		marshaled := pk.Bytes()
+		return abci.PubKey{
+			Type: ABCIPubKeyTypeBLS,
+			Data: marshaled,
 		}
 	default:
 		panic(fmt.Sprintf("unknown pubkey type: %v %v", pubKey, reflect.TypeOf(pubKey)))
@@ -203,6 +212,13 @@ func (pb2tm) PubKey(pubKey abci.PubKey) (crypto.PubKey, error) {
 		}
 		var pk secp256k1.PubKeySecp256k1
 		copy(pk[:], pubKey.Data)
+		return pk, nil
+	case ABCIPubKeyTypeBLS:
+		var pk bls.PubKeyBls
+		if err := cdc.UnmarshalBinaryBare(pubKey.Data, &pk); err != nil {
+			return nil, err
+		}
+
 		return pk, nil
 	default:
 		return nil, fmt.Errorf("Unknown pubkey type %v", pubKey.Type)


### PR DESCRIPTION
* Using 3rd party crypto library(herumi - https://github.com/herumi/bls/)
* Export serialized type for amino codec,
  amino failed UnmarshalBinaryBare to crypto.pubkey
  interface when direct using herumi instance.
* Update get_tools script for C implementation linking

----------------------------------------------------------------------------------
Changed the library between previous Pull request #5 for below  two reasons :
 (1) kyber library's unknown curve type 
  - see https://github.com/hdac-io/tendermint/pull/5#issuecomment-555808964
 
(2) BLS12-381 curve type with ETH 2.0 specification 
  - see https://github.com/ethereum/eth2.0-specs/blob/dev/specs/bls_signature.md