### PR TITLE
fix: wrong casting in crypto.PubKey Equals method

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -57,7 +57,14 @@ func (privKey PrivKeyBls) PubKey() crypto.PubKey {
 }
 
 func (privKey PrivKeyBls) Equals(rhs crypto.PrivKey) bool {
-	return privKey.IsEqual(&(rhs.(*PrivKeyBls).SecretKey))
+	switch rhs.(type) {
+	case PrivKeyBls:
+		sec := rhs.(PrivKeyBls).SecretKey
+		return privKey.IsEqual(&sec)
+
+	default:
+		return false
+	}
 }
 
 // MarshalAmino implement raw deep copy without json tag based default encode
@@ -90,5 +97,12 @@ func (pubKey PubKeyBls) VerifyBytes(msg []byte, sig []byte) bool {
 }
 
 func (pubKey PubKeyBls) Equals(rhs crypto.PubKey) bool {
-	return pubKey.IsEqual(&(rhs.(*PubKeyBls).PublicKey))
+	switch rhs.(type) {
+	case PubKeyBls:
+		pub := rhs.(PubKeyBls).PublicKey
+		return pubKey.IsEqual(&pub)
+
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
