### PR TITLE
feat: change scep256k1 address length to 32

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -134,7 +134,7 @@ const PubKeyEd25519Size = 32
 // PubKeyEd25519 implements crypto.PubKey for the Ed25519 signature scheme.
 type PubKeyEd25519 [PubKeyEd25519Size]byte
 
-// Address is the SHA256-20 of the raw pubkey bytes.
+// Address is the SHA256-32 of the raw pubkey bytes.
 func (pubKey PubKeyEd25519) Address() crypto.Address {
 	return crypto.Address(tmhash.SumTruncated(pubKey[:]))
 }

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"math/big"
 
-	"golang.org/x/crypto/ripemd160"
+	ripemd "github.com/maoxs2/go-ripemd"
 
 	secp256k1 "github.com/btcsuite/btcd/btcec"
 
@@ -139,15 +139,15 @@ const PubKeySecp256k1Size = 33
 // This prefix is followed with the x-coordinate.
 type PubKeySecp256k1 [PubKeySecp256k1Size]byte
 
-// Address returns a Bitcoin style addresses: RIPEMD160(SHA256(pubkey))
+// Address returns a Bitcoin style addresses: RIPEMD256(SHA256(pubkey))
 func (pubKey PubKeySecp256k1) Address() crypto.Address {
 	hasherSHA256 := sha256.New()
 	hasherSHA256.Write(pubKey[:]) // does not error
 	sha := hasherSHA256.Sum(nil)
 
-	hasherRIPEMD160 := ripemd160.New()
-	hasherRIPEMD160.Write(sha) // does not error
-	return crypto.Address(hasherRIPEMD160.Sum(nil))
+	md := ripemd.New256()
+	md.Write(sha)
+	return crypto.Address(md.Sum(nil))
 }
 
 // Bytes returns the pubkey marshalled with amino encoding.

--- a/crypto/tmhash/hash.go
+++ b/crypto/tmhash/hash.go
@@ -24,7 +24,7 @@ func Sum(bz []byte) []byte {
 //-------------------------------------------------------------
 
 const (
-	TruncatedSize = 20
+	TruncatedSize = 32
 )
 
 type sha256trunc struct {
@@ -58,8 +58,9 @@ func NewTruncated() hash.Hash {
 	}
 }
 
-// SumTruncated returns the first 20 bytes of SHA256 of the bz.
+// SumTruncated returns the first 32 bytes of SHA256 of the bz.
+// NOTE: friday changes the length of all addresses to 32 bytes.
 func SumTruncated(bz []byte) []byte {
 	hash := sha256.Sum256(bz)
-	return hash[:TruncatedSize]
+	return hash[:]
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/magiconair/properties v1.8.1
+	github.com/maoxs2/go-ripemd v0.0.0-20200326052756-bd1759ad7d10
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/maoxs2/go-ripemd v0.0.0-20200326052756-bd1759ad7d10 h1:NnHXwmmj75BfHY6QjueamfFOWyoiHRNG65zt2bBx7F0=
+github.com/maoxs2/go-ripemd v0.0.0-20200326052756-bd1759ad7d10/go.mod h1:RPN95RsGHNuR+OUN9pD6OKS7yE3Q966yIMSXYZsgnbI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=


### PR DESCRIPTION
The builtin crypto library does not have ripemd-256.