### PR TITLE
improve catchup gossip

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -26,7 +26,8 @@ const (
 	// stopSyncingDurationMinutes = 10
 
 	// ask for best height every 10s
-	statusUpdateIntervalSeconds = 10
+	// NOTE: friday change update interval seconds to 1s, avg block time so faster
+	statusUpdateIntervalSeconds = 1
 	// check if we should switch to consensus reactor
 	switchToConsensusIntervalSeconds = 1
 

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -22,7 +22,7 @@ const (
 	trySendIntervalMS = 10
 
 	// ask for best height every 10s
-	statusUpdateIntervalSeconds = 10
+	statusUpdateIntervalSeconds = 1
 
 	// NOTE: keep up to date with bcBlockResponseMessage
 	bcBlockResponseMessagePrefixSize   = 4

--- a/consensus/friday/reactor.go
+++ b/consensus/friday/reactor.go
@@ -499,6 +499,7 @@ OUTER_LOOP:
 			return
 		}
 
+		continuous := false
 		// Gossip for catchup
 		if ps.GetHeight() < conR.conS.GetLastHeight() {
 			ps.GetRoundStatesMap().Range(func(key, value interface{}) bool {
@@ -519,6 +520,7 @@ OUTER_LOOP:
 					}
 
 					conR.gossipDataForCatchupPerPRS(prs, ps, peer)
+					continuous = true
 				}
 
 				return true
@@ -545,7 +547,9 @@ OUTER_LOOP:
 		}
 
 		// Nothing to do. Sleep.
-		time.Sleep(conR.conS.config.PeerGossipSleepDuration)
+		if !continuous {
+			time.Sleep(conR.conS.config.PeerGossipSleepDuration)
+		}
 		continue OUTER_LOOP
 	}
 }
@@ -668,6 +672,7 @@ OUTER_LOOP:
 			return
 		}
 
+		continuous := false
 		ps.GetRoundStatesMap().Range(func(key, value interface{}) bool {
 			height := key.(int64)
 			commitedHeight := conR.conS.GetLastHeight()
@@ -678,6 +683,7 @@ OUTER_LOOP:
 				if ps.PickSendVote(commit) {
 					logger.Info("Picked Catchup commit to send", "height", height)
 				}
+				continuous = true
 				return true
 
 			} else if height != 0 && height > commitedHeight {
@@ -692,7 +698,9 @@ OUTER_LOOP:
 			return false
 		})
 
-		time.Sleep(conR.conS.config.PeerGossipSleepDuration)
+		if !continuous {
+			time.Sleep(conR.conS.config.PeerGossipSleepDuration)
+		}
 		continue OUTER_LOOP
 	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -41,7 +41,7 @@ type Mempool interface {
 	Unlock()
 
 	// Reserve Update marking reserve the mempool that the given txs were received proposal block.
-	Reserve(blockTxs types.Txs)
+	Reserve(blockHeight int64, blockTxs types.Txs)
 
 	// Unreserve Update unmarking reserve the mempool that the given txs were previous failed round proposal block.
 	Unreserve(blockTxs types.Txs)

--- a/mock/mempool.go
+++ b/mock/mempool.go
@@ -22,10 +22,10 @@ func (Mempool) CheckTxWithInfo(_ types.Tx, _ func(*abci.Response),
 	_ mempl.TxInfo) error {
 	return nil
 }
-func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs { return types.Txs{} }
-func (Mempool) ReapMaxTxs(n int) types.Txs              { return types.Txs{} }
-func (Mempool) Reserve(blockTxs types.Txs)              {}
-func (Mempool) Unreserve(blockTxs types.Txs)            {}
+func (Mempool) ReapMaxBytesMaxGas(_, _ int64) types.Txs       { return types.Txs{} }
+func (Mempool) ReapMaxTxs(n int) types.Txs                    { return types.Txs{} }
+func (Mempool) Reserve(blockHeight int64, blockTxs types.Txs) {}
+func (Mempool) Unreserve(blockTxs types.Txs)                  {}
 func (Mempool) Update(
 	_ int64,
 	_ types.Txs,

--- a/state/execution.go
+++ b/state/execution.go
@@ -153,7 +153,7 @@ func (blockExec *BlockExecutor) ReserveBlock(state State, block *types.Block) er
 	if block == nil {
 		return fmt.Errorf("block is nil")
 	}
-	blockExec.mempool.Reserve(block.Txs)
+	blockExec.mempool.Reserve(block.Height, block.Txs)
 	return nil
 }
 


### PR DESCRIPTION
1. change send order in GossipDataRoutine - first-proposal, second-block part
2. change cleanup commited height of PeerState - it's for entering EnterCommit but not yet receiving a proposal block.
3. The catch-up situation and the progressing situation are further divided.
4. In the case of catch-up, it continues without sleep.