### PR TITLE
feat: add toggle for consensus module

### DIFF
--- a/blockchain/v1/reactor_fsm.go
+++ b/blockchain/v1/reactor_fsm.go
@@ -45,7 +45,7 @@ type BcReactorFSM struct {
 }
 
 // NewFSM creates a new reactor FSM.
-func NewFSM(height int64, toBcR bcReactor, version string) *BcReactorFSM {
+func NewFSM(height int64, toBcR bcReactor, consensusModule string) *BcReactorFSM {
 
 	fsm := BcReactorFSM{
 		state:     unknown,
@@ -54,7 +54,7 @@ func NewFSM(height int64, toBcR bcReactor, version string) *BcReactorFSM {
 	}
 
 	var pool IBlockPool
-	switch version {
+	switch consensusModule {
 	case "tendermint":
 		pool = NewBlockPool(height, toBcR)
 	case "friday":
@@ -62,7 +62,7 @@ func NewFSM(height int64, toBcR bcReactor, version string) *BcReactorFSM {
 			return fsm.toBcR.lenULB()
 		})
 	default:
-		panic(fmt.Sprintf("invalid pool version %s", version))
+		panic(fmt.Sprintf("invalid consensusModule %s", consensusModule))
 	}
 	fsm.pool = pool
 	return &fsm

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -29,18 +29,18 @@ func initFilesWithConfig(config *cfg.Config) error {
 	privValStateFile := config.PrivValidatorStateFile()
 	var pv types.PrivValidator
 	if cmn.FileExists(privValKeyFile) {
-		switch config.Consensus.Version {
+		switch config.Consensus.Module {
 		case "tendermint":
 			pv = privval.LoadFilePV(privValKeyFile, privValStateFile)
 		case "friday":
 			pv = privval.LoadFridayFilePV(privValKeyFile, privValStateFile)
 		default:
-			return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+			return fmt.Errorf("invalid consensus module %s", config.Consensus.Module)
 		}
 		logger.Info("Found private validator", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)
 	} else {
-		switch config.Consensus.Version {
+		switch config.Consensus.Module {
 		case "tendermint":
 			fpv := privval.GenFilePV(privValKeyFile, privValStateFile)
 			fpv.Save()
@@ -50,7 +50,7 @@ func initFilesWithConfig(config *cfg.Config) error {
 			ffpv.Save()
 			pv = ffpv
 		default:
-			return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+			return fmt.Errorf("invalid consensus module %s", config.Consensus.Module)
 		}
 		logger.Info("Generated private validator", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)
@@ -72,19 +72,19 @@ func initFilesWithConfig(config *cfg.Config) error {
 		logger.Info("Found genesis file", "path", genFile)
 	} else {
 		var consensusParams *types.ConsensusParams
-		switch config.Consensus.Version {
+		switch config.Consensus.Module {
 		case "tednermint":
 			consensusParams = types.DefaultConsensusParams()
 		case "friday":
 			consensusParams = types.DefaultFridayConsensusParams()
 		default:
-			return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+			return fmt.Errorf("invalid consensus module %s", config.Consensus.Module)
 		}
 		genDoc := types.GenesisDoc{
 			ChainID:         fmt.Sprintf("test-chain-%v", cmn.RandStr(6)),
 			GenesisTime:     tmtime.Now(),
 			ConsensusParams: consensusParams,
-			ConsensusModule: config.Consensus.Version,
+			ConsensusModule: config.Consensus.Module,
 		}
 		key := pv.GetPubKey()
 		genDoc.Validators = []types.GenesisValidator{{

--- a/cmd/tendermint/commands/init.go
+++ b/cmd/tendermint/commands/init.go
@@ -71,10 +71,20 @@ func initFilesWithConfig(config *cfg.Config) error {
 	if cmn.FileExists(genFile) {
 		logger.Info("Found genesis file", "path", genFile)
 	} else {
+		var consensusParams *types.ConsensusParams
+		switch config.Consensus.Version {
+		case "tednermint":
+			consensusParams = types.DefaultConsensusParams()
+		case "friday":
+			consensusParams = types.DefaultFridayConsensusParams()
+		default:
+			return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+		}
 		genDoc := types.GenesisDoc{
 			ChainID:         fmt.Sprintf("test-chain-%v", cmn.RandStr(6)),
 			GenesisTime:     tmtime.Now(),
-			ConsensusParams: types.DefaultFridayConsensusParams(),
+			ConsensusParams: consensusParams,
+			ConsensusModule: config.Consensus.Version,
 		}
 		key := pv.GetPubKey()
 		genDoc.Validators = []types.GenesisValidator{{

--- a/cmd/tendermint/commands/reset_priv_validator.go
+++ b/cmd/tendermint/commands/reset_priv_validator.go
@@ -64,7 +64,7 @@ func ResetAll(dbDir, addrBookFile, privValKeyFile, privValStateFile string, logg
 
 func resetFilePV(privValKeyFile, privValStateFile string, logger log.Logger) {
 	if _, err := os.Stat(privValKeyFile); err == nil {
-		switch config.Consensus.Version {
+		switch config.Consensus.Module {
 		case "tendermint":
 			pv := privval.LoadFilePVEmptyState(privValKeyFile, privValStateFile)
 			pv.Reset()
@@ -72,14 +72,14 @@ func resetFilePV(privValKeyFile, privValStateFile string, logger log.Logger) {
 			pv := privval.LoadFridayFilePVEmptyState(privValKeyFile, privValStateFile)
 			pv.Reset()
 		default:
-			logger.Error("invalid consensus version", "version", config.Consensus.Version)
+			logger.Error("invalid consensus module", "module", config.Consensus.Module)
 			return
 		}
 
 		logger.Info("Reset private validator file to genesis state", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)
 	} else {
-		switch config.Consensus.Version {
+		switch config.Consensus.Module {
 		case "tendermint":
 			pv := privval.GenFilePV(privValKeyFile, privValStateFile)
 			pv.Save()
@@ -87,7 +87,7 @@ func resetFilePV(privValKeyFile, privValStateFile string, logger log.Logger) {
 			pv := privval.GenFridayFilePV(privValKeyFile, privValStateFile)
 			pv.Save()
 		default:
-			logger.Error("invalid consensus version", "version", config.Consensus.Version)
+			logger.Error("invalid consensus module", "version", config.Consensus.Module)
 			return
 		}
 

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -161,20 +161,20 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 
 	// Generate genesis doc from generated validators
 	var consensusParams *types.ConsensusParams
-	switch config.Consensus.Version {
+	switch config.Consensus.Module {
 	case "friday":
 		consensusParams = types.DefaultFridayConsensusParams()
 	case "tendermint":
 		consensusParams = types.DefaultConsensusParams()
 	default:
-		return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+		return fmt.Errorf("invalid consensus module %s", config.Consensus.Module)
 	}
 	genDoc := &types.GenesisDoc{
 		ChainID:         "chain-" + cmn.RandStr(6),
 		ConsensusParams: consensusParams,
 		GenesisTime:     tmtime.Now(),
 		Validators:      genVals,
-		ConsensusModule: config.Consensus.Version,
+		ConsensusModule: config.Consensus.Module,
 	}
 
 	// Write genesis file.

--- a/cmd/tendermint/commands/testnet.go
+++ b/cmd/tendermint/commands/testnet.go
@@ -160,11 +160,21 @@ func testnetFiles(cmd *cobra.Command, args []string) error {
 	}
 
 	// Generate genesis doc from generated validators
+	var consensusParams *types.ConsensusParams
+	switch config.Consensus.Version {
+	case "friday":
+		consensusParams = types.DefaultFridayConsensusParams()
+	case "tendermint":
+		consensusParams = types.DefaultConsensusParams()
+	default:
+		return fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+	}
 	genDoc := &types.GenesisDoc{
 		ChainID:         "chain-" + cmn.RandStr(6),
-		ConsensusParams: types.DefaultFridayConsensusParams(),
+		ConsensusParams: consensusParams,
 		GenesisTime:     tmtime.Now(),
 		Validators:      genVals,
+		ConsensusModule: config.Consensus.Version,
 	}
 
 	// Write genesis file.

--- a/config/config.go
+++ b/config/config.go
@@ -759,7 +759,7 @@ func (cfg *FastSyncConfig) ValidateBasic() error {
 // ConsensusConfig defines the configuration for the Tendermint consensus service,
 // including timeouts and details about the WAL and the block structure.
 type ConsensusConfig struct {
-	Version string `mapstructure:"version"`
+	Module string `mapstructure:"module"`
 
 	RootDir string `mapstructure:"home"`
 	WalPath string `mapstructure:"wal_file"`
@@ -788,7 +788,7 @@ type ConsensusConfig struct {
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {
 	return &ConsensusConfig{
-		Version:                     "tendermint",
+		Module:                      "tendermint",
 		WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
 		TimeoutPropose:              3000 * time.Millisecond,
 		TimeoutProposeDelta:         500 * time.Millisecond,
@@ -808,7 +808,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 // DefaultFridayConsensusConfig returns a specialized friday default configuration for the consensus service
 func DefaultFridayConsensusConfig() *ConsensusConfig {
 	cfg := DefaultConsensusConfig()
-	cfg.Version = "friday"
+	cfg.Module = "friday"
 	return cfg
 }
 
@@ -831,7 +831,7 @@ func TestConsensusConfig() *ConsensusConfig {
 // TestFridayConsensusConfig returns a configuration for testing the friday consensus service
 func TestFridayConsensusConfig() *ConsensusConfig {
 	cfg := TestConsensusConfig()
-	cfg.Version = "friday"
+	cfg.Module = "friday"
 	return cfg
 }
 
@@ -883,11 +883,11 @@ func (cfg *ConsensusConfig) SetWalFile(walFile string) {
 // returns an error if any check fails.
 func (cfg *ConsensusConfig) ValidateBasic() error {
 
-	switch cfg.Version {
+	switch cfg.Module {
 	case "tendermint":
 	case "friday":
 	default:
-		return errors.New("invalid consensus version")
+		return errors.New("invalid consensus module")
 	}
 
 	if cfg.TimeoutPropose < 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,7 @@ func DefaultFridayConfig() *Config {
 		RPC:             DefaultRPCConfig(),
 		P2P:             DefaultP2PConfig(),
 		Mempool:         DefaultMempoolConfig(),
-		FastSync:        DefaultFridayFastSyncConfig(),
+		FastSync:        DefaultFastSyncConfig(),
 		Consensus:       DefaultFridayConsensusConfig(),
 		TxIndex:         DefaultTxIndexConfig(),
 		Instrumentation: DefaultInstrumentationConfig(),
@@ -120,7 +120,7 @@ func TestFridayConfig() *Config {
 		RPC:             TestRPCConfig(),
 		P2P:             TestP2PConfig(),
 		Mempool:         TestMempoolConfig(),
-		FastSync:        TestFridayFastSyncConfig(),
+		FastSync:        TestFastSyncConfig(),
 		Consensus:       TestFridayConsensusConfig(),
 		TxIndex:         TestTxIndexConfig(),
 		Instrumentation: TestInstrumentationConfig(),
@@ -725,34 +725,19 @@ func (cfg *MempoolConfig) ValidateBasic() error {
 
 // FastSyncConfig defines the configuration for the Tendermint fast sync service
 type FastSyncConfig struct {
-	Version     string `mapstructure:"version"`
-	PoolVersion string `mapstructure:"pool_version"`
+	Version string `mapstructure:"version"`
 }
 
 // DefaultFastSyncConfig returns a default configuration for the fast sync service
 func DefaultFastSyncConfig() *FastSyncConfig {
 	return &FastSyncConfig{
-		Version:     "v0",
-		PoolVersion: "tendermint",
-	}
-}
-
-// DefaultFridayFastSyncConfig returns a default specialized friday configuration for the fast sync service
-func DefaultFridayFastSyncConfig() *FastSyncConfig {
-	return &FastSyncConfig{
-		Version:     "v0",
-		PoolVersion: "friday",
+		Version: "v0",
 	}
 }
 
 // TestFastSyncConfig returns a default configuration for the fast sync.
 func TestFastSyncConfig() *FastSyncConfig {
 	return DefaultFastSyncConfig()
-}
-
-// TestFridayFastSyncConfig returns a default configuration for the fast sync.
-func TestFridayFastSyncConfig() *FastSyncConfig {
-	return DefaultFridayFastSyncConfig()
 }
 
 // ValidateBasic performs basic validation.
@@ -763,13 +748,6 @@ func (cfg *FastSyncConfig) ValidateBasic() error {
 	case "v1":
 	default:
 		err = fmt.Errorf("unknown fastsync version %s", cfg.Version)
-	}
-
-	switch cfg.PoolVersion {
-	case "tendermint":
-	case "friday":
-	default:
-		err = fmt.Errorf("unknown fastsync pool version %s", cfg.PoolVersion)
 	}
 
 	return err

--- a/config/toml.go
+++ b/config/toml.go
@@ -318,7 +318,7 @@ version = "{{ .FastSync.Version }}"
 # Consensus version to use:
 #   1) "tendermint" (default) - the default consensus implementation
 #   2) "friday" - the friday consensus implementation 
-version = "{{ .Consensus.Version }}"
+module = "{{ .Consensus.Module }}"
 
 wal_file = "{{ js .Consensus.WalPath }}"
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -312,11 +312,6 @@ max_tx_bytes = {{ .Mempool.MaxTxBytes }}
 #   2) "v1" - refactor of v0 version for better testability
 version = "{{ .FastSync.Version }}"
 
-# Fast Sync pool version to use:
-#   1) "tendermint" (default) - the default fast sync implementation
-#   2) "friday" - the customize implementation for friday consensus
-pool_version = "{{ .FastSync.PoolVersion }}"
-
 ##### consensus configuration options #####
 [consensus]
 

--- a/node/node.go
+++ b/node/node.go
@@ -308,6 +308,7 @@ func logNodeStartupInfo(state sm.State, pubKey crypto.PubKey, logger, consensusL
 		"software", version.TMCoreSemVer,
 		"block", version.BlockProtocol,
 		"p2p", version.P2PProtocol,
+		"module", state.Version.Consensus.Module,
 	)
 
 	// If the state and software differ in block version, at least log it.

--- a/node/node.go
+++ b/node/node.go
@@ -111,13 +111,13 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 	}
 
 	var privVal types.PrivValidator
-	switch config.Consensus.Version {
+	switch config.Consensus.Module {
 	case "tendermint":
 		privVal = privval.LoadOrGenFilePV(newPrivValKey, newPrivValState)
 	case "friday":
 		privVal = privval.LoadOrGenFridayFilePV(newPrivValKey, newPrivValState)
 	default:
-		return nil, fmt.Errorf("invalid consensus version %s", config.Consensus.Version)
+		return nil, fmt.Errorf("invalid consensus module %s", config.Consensus.Module)
 	}
 
 	return NewNode(config,
@@ -281,7 +281,7 @@ func doHandshake(config *cfg.Config, stateDB dbm.DB, state sm.State, blockStore 
 	genDoc *types.GenesisDoc, eventBus *types.EventBus, proxyApp proxy.AppConns, consensusLogger log.Logger) error {
 
 	// Handshaker it's only used here. don't abstract.
-	switch config.Consensus.Version {
+	switch config.Consensus.Module {
 	case "tendermint":
 		handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc)
 		handshaker.SetLogger(consensusLogger)
@@ -407,7 +407,7 @@ func createConsensusReactor(config *cfg.Config,
 	var consensusState consensus.IConsensusState
 	var consensusReactor consensus.IConsensusReactor
 
-	switch config.Consensus.Version {
+	switch config.Consensus.Module {
 	case "tendermint":
 		tmConsensusState := consensus.NewConsensusState(
 			config.Consensus,

--- a/node/node.go
+++ b/node/node.go
@@ -381,9 +381,9 @@ func createBlockchainReactor(config *cfg.Config,
 
 	switch config.FastSync.Version {
 	case "v0":
-		bcReactor = bcv0.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync, config.FastSync.PoolVersion)
+		bcReactor = bcv0.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	case "v1":
-		bcReactor = bcv1.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync, config.FastSync.PoolVersion)
+		bcReactor = bcv1.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	default:
 		return nil, fmt.Errorf("unknown fastsync version %s", config.FastSync.Version)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -267,6 +267,7 @@ func MakeGenesisState(genDoc *types.GenesisDoc) (State, error) {
 		nextValidatorSet = types.NewValidatorSet(validators).CopyIncrementProposerPriority(1)
 	}
 
+	initStateVersion.Consensus.Module = genDoc.ConsensusModule
 	return State{
 		Version: initStateVersion,
 		ChainID: genDoc.ChainID,

--- a/state/validation.go
+++ b/state/validation.go
@@ -14,7 +14,7 @@ import (
 // Validate block
 
 func validateBlock(store BlockStore, evidencePool EvidencePool, stateDB dbm.DB, state State, block *types.Block) error {
-	if state.ConsensusParams.Block.LenULB != 0 {
+	if state.Version.Consensus.Module == "friday" {
 		return fridayValidateBlock(store, evidencePool, stateDB, state, block)
 	} else {
 		return tmValidateBlock(evidencePool, stateDB, state, block)

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -37,6 +37,7 @@ type GenesisValidator struct {
 type GenesisDoc struct {
 	GenesisTime     time.Time          `json:"genesis_time"`
 	ChainID         string             `json:"chain_id"`
+	ConsensusModule string             `json:"consensus_module"`
 	ConsensusParams *ConsensusParams   `json:"consensus_params,omitempty"`
 	Validators      []GenesisValidator `json:"validators,omitempty"`
 	AppHash         cmn.HexBytes       `json:"app_hash"`
@@ -94,6 +95,12 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 		genDoc.GenesisTime = tmtime.Now()
 	}
 
+	switch genDoc.ConsensusModule {
+	case "friday":
+	case "tendermint":
+	default:
+		return errors.Errorf("invalid consenssus module %s", genDoc.ConsensusModule)
+	}
 	return nil
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -61,6 +61,7 @@ type App struct {
 // including all blockchain data structures and the rules of the application's
 // state transition machine.
 type Consensus struct {
-	Block Protocol `json:"block"`
-	App   Protocol `json:"app"`
+	Block  Protocol `json:"block"`
+	App    Protocol `json:"app"`
+	Module string   `json:"module"`
 }


### PR DESCRIPTION
if you want toggle between tendermint and friday, 
change config.Consensus.Module, It will creates a matching Genesis.json.

This PR supports selection through the init cmd on the friday platform. (ex: nodef init monikername friday, nodef init monikername tendermint)

The test confirmed that the consensus was selected as intended by changing the localnet config code directly.(https://github.com/hdac-io/tendermint/blob/eb53ac7c4ab9c997a57bc39adbe5f85fe783b74e/cmd/tendermint/commands/testnet.go#L95)
If you're running Tendermint directly, if you want to choose a consensus, you have to edit the code yourself. Legacy tendermint code with config as a global variable has require many modifications.(https://github.com/hdac-io/tendermint/blob/8c1454912aa4431581dd3b8ea47f29ae75ef44f5/cmd/tendermint/commands/root.go#L17)

To select through the arguments of tendermint init and localnet-start command will be added later.
