### PR TITLE
Private/jiyong minimum blocktime

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -809,6 +809,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 func DefaultFridayConsensusConfig() *ConsensusConfig {
 	cfg := DefaultConsensusConfig()
 	cfg.Module = "friday"
+	cfg.TimeoutCommit = 800 * time.Millisecond
 	return cfg
 }
 


### PR DESCRIPTION
The meaning of TimeoutCommit has changed slightly.
Before-TM)After receiving 2/3 + 1 precommit
After-Friday) After Block txs execution and update state

because may fail even after 2/3 precommit on friday consensus.
(Failure to linked previous block)