### PR TITLE
(WIP) Private/jiyong add timeout previous failure

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -330,6 +330,8 @@ timeout_prevote_delta = "{{ .Consensus.TimeoutPrevoteDelta }}"
 timeout_precommit = "{{ .Consensus.TimeoutPrecommit }}"
 timeout_precommit_delta = "{{ .Consensus.TimeoutPrecommitDelta }}"
 timeout_commit = "{{ .Consensus.TimeoutCommit }}"
+timeout_previous_failure = "{{ .Consensus.TimeoutPreviousFailure }}"
+timeout_previous_failure_delta = "{{ .Consensus.TimeoutPreviousFailureDelta }}"
 
 # Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
 skip_timeout_commit = {{ .Consensus.SkipTimeoutCommit }}

--- a/consensus/friday/state.go
+++ b/consensus/friday/state.go
@@ -1692,6 +1692,11 @@ func (cs *ConsensusState) finalizeCommit(height int64) {
 			heightRound.LockedBlockParts = nil
 
 			cs.eventBus.PublishEventUnlock(heightRound.RoundStateEvent())
+			// NOTE: If the consensus of the previously connected block fails,
+			// sleep to sufficient time for receive a new previous block and consensus to proceed.
+			// If there is no waiting time, the connected now height blocks will fail consecutively,
+			// so round number will not dcrease.
+			time.Sleep(cs.config.PreviousFailure(heightRound.Round))
 			cs.enterNewRound(height, heightRound.Round+1)
 			return
 


### PR DESCRIPTION
If the consensus of the previously connected block fails, sleep to sufficient time for receive a new previous block and consensus to proceed.

If there is no waiting time, the connected now height blocks will fail consecutively, so round number will not dcrease.

* I am monitoring the result with kvstore cloud testnet. If there is no abnormality result after a next day, I will remove the 'WIP' and request a review.